### PR TITLE
fix: keep strike price keys as strings

### DIFF
--- a/lib/DhanHQ/models/option_chain.rb
+++ b/lib/DhanHQ/models/option_chain.rb
@@ -36,10 +36,10 @@ module DhanHQ
 
         private
 
-        # **Filters valid strikes where `ce` or `pe` has `last_price > 0` and converts strike prices to integers**
+        # **Filters valid strikes where `ce` or `pe` has `last_price > 0` and keeps strike prices as-is**
         #
         # @param data [Hash] The API response data
-        # @return [Hash] The filtered option chain data with integer strike prices
+        # @return [Hash] The filtered option chain data with original strike price keys
         def filter_valid_strikes(data)
           return {} unless data.is_a?(Hash) && data.key?(:oc)
 
@@ -48,10 +48,7 @@ module DhanHQ
             pe_last_price = strike_data.dig("pe", "last_price").to_f
 
             # Only keep strikes where at least one of CE or PE has a valid last_price
-            if ce_last_price.positive? || pe_last_price.positive?
-              # Convert strike price to integer and store in result
-              result[strike_price.to_f.to_i] = strike_data
-            end
+            result[strike_price] = strike_data if ce_last_price.positive? || pe_last_price.positive?
           end
 
           data.merge(oc: filtered_oc)

--- a/spec/dhan_hq/models/option_chain_spec.rb
+++ b/spec/dhan_hq/models/option_chain_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe DhanHQ::Models::OptionChain, vcr: { cassette_name: "models/option
     expect(response).to be_a(Hash)
     expect(response[:last_price]).to be > 0
 
-    # Ensure strike prices are integers
-    expect(response[:oc].keys).to all(be_a(Integer))
+    # Ensure strike prices retain their original format (strings)
+    expect(response[:oc].keys).to all(be_a(String))
 
     # Ensure only valid strikes with last_price > 0 are included
     response[:oc].each_value do |strike_data|


### PR DESCRIPTION
## Summary
- retain strike price keys as provided in option chain responses
- update option chain spec to expect string strike prices

## Testing
- `bundle exec rspec`
- `bundle exec rake` *(fails: RSpec/AnyInstance and other RuboCop offenses)*

------
https://chatgpt.com/codex/tasks/task_e_688f8c9066dc832a81663012892b5fa3