### PR TITLE
v3.0.0: rename gem to dhan_hq, scope TA/analysis as opt-in, widen coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## [3.0.0] - 2026-05-19
+
+### Breaking Changes
+
+- **Gem renamed on RubyGems**: `DhanHQ` → `dhan_hq`. Update your Gemfile: `gem 'dhan_hq'`.
+- **TA and analysis modules are now opt-in**. `require 'dhan_hq'` no longer auto-loads `DhanHQ::Analysis::*` or `TA::*`. Explicitly require what you need:
+  ```ruby
+  require 'dhan_hq/analysis'  # OptionsBuyingAdvisor, MultiTimeframeAnalyzer
+  require 'dhan_hq/ta'        # TA::TechnicalAnalysis, TA::Fetcher, TA::Candles
+  ```
+
+### Changed
+
+- `exe/DhanHQ` now correctly uses `require "dhan_hq"`.
+- SimpleCov tracks all `lib/**/*.rb` files (was models-only).
+
+---
+
 ## [2.8.0] - 2026-03-21
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    DhanHQ (2.8.0)
+    dhan_hq (3.0.0)
       activesupport
       base64
       bindata
@@ -295,8 +295,8 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  DhanHQ!
   debug
+  dhan_hq!
   dotenv
   rack (~> 2.0)
   rake (~> 13.0)
@@ -316,7 +316,6 @@ DEPENDENCIES
   yard (~> 0.9.37)
 
 CHECKSUMS
-  DhanHQ (2.8.0)
   activesupport (8.1.2) sha256=88842578ccd0d40f658289b0e8c842acfe9af751afee2e0744a7873f50b6fdae
   addressable (2.8.9) sha256=cc154fcbe689711808a43601dee7b980238ce54368d23e127421753e46895485
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
@@ -333,6 +332,7 @@ CHECKSUMS
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
   descendants_tracker (0.0.4) sha256=e9c41dd4cfbb85829a9301ea7e7c48c2a03b26f09319db230e6479ccdc780897
+  dhan_hq (3.0.0)
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
   dotenv (3.2.0) sha256=e375b83121ea7ca4ce20f214740076129ab8514cd81378161f11c03853fe619d

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DhanHQ — The Ruby SDK for Dhan API v2
 
-[![Gem Version](https://badge.fury.io/rb/DhanHQ.svg)](https://rubygems.org/gems/DhanHQ)
+[![Gem Version](https://badge.fury.io/rb/dhan_hq.svg)](https://rubygems.org/gems/dhan_hq)
 [![CI](https://github.com/shubhamtaywade82/dhanhq-client/actions/workflows/main.yml/badge.svg)](https://github.com/shubhamtaywade82/dhanhq-client/actions/workflows/main.yml)
 [![Ruby](https://img.shields.io/badge/ruby-%3E%3D%203.2-ruby.svg)](https://www.ruby-lang.org)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.txt)
@@ -29,7 +29,7 @@ This is closer to trading infrastructure than a simple API client.
 
 ```ruby
 # Gemfile
-gem 'DhanHQ'
+gem 'dhan_hq'
 ```
 
 ```ruby
@@ -140,29 +140,36 @@ See [ARCHITECTURE.md](ARCHITECTURE.md), [docs/TESTING_GUIDE.md](docs/TESTING_GUI
 
 ```ruby
 # Gemfile (recommended)
-gem 'DhanHQ'
+gem 'dhan_hq'
 ```
 
 ```bash
 bundle install
 # or
-gem install DhanHQ
+gem install dhan_hq
 ```
 
-> **Bleeding edge?** Use `gem 'DhanHQ', git: 'https://github.com/shubhamtaywade82/dhanhq-client.git', branch: 'main'` only if you need unreleased features.
+> **Bleeding edge?** Use `gem 'dhan_hq', git: 'https://github.com/shubhamtaywade82/dhanhq-client.git', branch: 'main'` only if you need unreleased features.
 
 **`bundle update` / `bundle install` warnings** — If you see "Local specification for rexml-3.2.8 has different dependencies" or "Unresolved or ambiguous specs during Gem::Specification.reset: psych", the bundle still completes successfully. To clear the rexml warning once, run: `gem cleanup rexml`. The psych message is a known Bundler quirk and can be ignored.
 
-### ⚠️ Breaking Change (v2.1.5+)
+### ⚠️ Breaking Change (v3.0.0)
 
-The require statement changed:
+The gem name changed on RubyGems:
 
 ```ruby
-# Before         # Now
-require 'DhanHQ'  →  require 'dhan_hq'
+# Before (≤ 2.x)   # Now (3.0+)
+gem 'DhanHQ'     →  gem 'dhan_hq'
 ```
 
-The gem name in your Gemfile stays `DhanHQ` — only the `require` changes.
+### Optional features
+
+The core SDK (`require 'dhan_hq'`) only loads the API client. Technical analysis and the options advisor are opt-in:
+
+```ruby
+require 'dhan_hq/analysis'  # DhanHQ::Analysis::OptionsBuyingAdvisor, MultiTimeframeAnalyzer
+require 'dhan_hq/ta'        # TA::TechnicalAnalysis, TA::Fetcher, TA::Candles
+```
 
 ---
 
@@ -484,6 +491,10 @@ bundle exec rake          # run tests
 bundle exec rubocop       # lint
 bin/console               # interactive console
 ```
+
+## Disclaimer
+
+This gem is an independent, community-maintained project and is **not officially affiliated with, endorsed by, or supported by Dhan (Mirae Asset Capital Markets)**. Trading in financial instruments carries significant risk. Use this SDK at your own risk and always verify order placement in a sandbox environment before going live.
 
 ## License
 

--- a/dhan_hq.gemspec
+++ b/dhan_hq.gemspec
@@ -3,7 +3,7 @@
 require_relative "lib/DhanHQ/version"
 
 Gem::Specification.new do |spec|
-  spec.name = "DhanHQ"
+  spec.name = "dhan_hq"
   spec.version = DhanHQ::VERSION
   spec.authors = ["Shubham Taywade"]
   spec.email = ["shubhamtaywade82@gmail.com"]

--- a/docs/HOW_TO_USE_DHAN_API_WITH_RUBY.md
+++ b/docs/HOW_TO_USE_DHAN_API_WITH_RUBY.md
@@ -14,7 +14,7 @@ This guide is the practical path for:
 Add the gem:
 
 ```ruby
-gem "DhanHQ"
+gem "dhan_hq"
 ```
 
 Then configure it from environment variables:

--- a/docs/TECHNICAL_ANALYSIS.md
+++ b/docs/TECHNICAL_ANALYSIS.md
@@ -65,7 +65,7 @@ indicators = TA::TechnicalAnalysis.new.compute_from_file(
 ## Analyze Multi-Timeframe Bias
 
 ```ruby
-require "DhanHQ"
+require "dhan_hq/analysis"
 
 analyzer = DhanHQ::Analysis::MultiTimeframeAnalyzer.new(data: indicators)
 summary = analyzer.call

--- a/lib/DhanHQ/version.rb
+++ b/lib/DhanHQ/version.rb
@@ -2,5 +2,5 @@
 
 module DhanHQ
   # Semantic version of the DhanHQ client gem.
-  VERSION = "2.8.0"
+  VERSION = "3.0.0"
 end

--- a/lib/dhan_hq.rb
+++ b/lib/dhan_hq.rb
@@ -34,10 +34,8 @@ module DhanHQ
     "ws" => "WS"
   )
   LOADER.push_dir(File.join(__dir__, "DhanHQ"), namespace: self)
-  LOADER.push_dir(File.join(__dir__, "dhanhq"), namespace: self)
   LOADER.collapse(File.join(__dir__, "DhanHQ", "core"))
   LOADER.collapse(File.join(__dir__, "DhanHQ", "helpers"))
-  LOADER.collapse(File.join(__dir__, "dhanhq", "analysis", "helpers"))
   LOADER.ignore(
     File.join(__dir__, "DhanHQ", "errors.rb"),
     File.join(__dir__, "DhanHQ", "version.rb")

--- a/lib/dhan_hq/analysis.rb
+++ b/lib/dhan_hq/analysis.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "dhan_hq"
+
+require_relative "../dhanhq/contracts/options_buying_advisor_contract"
+require_relative "../dhanhq/analysis/helpers/bias_aggregator"
+require_relative "../dhanhq/analysis/helpers/moneyness_helper"
+require_relative "../dhanhq/analysis/multi_timeframe_analyzer"
+require_relative "../dhanhq/analysis/options_buying_advisor"

--- a/lib/dhan_hq/ta.rb
+++ b/lib/dhan_hq/ta.rb
@@ -1,4 +1,5 @@
-#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 require "dhan_hq"
+
+require_relative "../ta"

--- a/spec/dhan_hq/analysis/multi_timeframe_analyzer_spec.rb
+++ b/spec/dhan_hq/analysis/multi_timeframe_analyzer_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "dhan_hq"
+require "dhan_hq/analysis"
 
 RSpec.describe DhanHQ::Analysis::MultiTimeframeAnalyzer do
   let(:valid_data) do

--- a/spec/dhan_hq/analysis/options_buying_advisor_spec.rb
+++ b/spec/dhan_hq/analysis/options_buying_advisor_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "dhan_hq"
+require "dhan_hq/analysis"
 
 RSpec.describe DhanHQ::Analysis::OptionsBuyingAdvisor do
   let(:data) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,12 +5,9 @@ if ENV["SIMPLECOV"] == "true" || ENV["COVERAGE"] == "true"
 
   SimpleCov.start do
     enable_coverage :branch
-    track_files "lib/DhanHQ/models/**/*.rb"
+    track_files "lib/**/*.rb"
     add_filter "/spec/"
     add_filter "/tmp/"
-    add_filter do |source_file|
-      !source_file.filename.include?("/lib/DhanHQ/models/")
-    end
   end
 end
 


### PR DESCRIPTION
- Rename RubyGems published name from DhanHQ to dhan_hq (gemspec file +
  spec.name). Users update Gemfile to gem 'dhan_hq'.
- Bump VERSION to 3.0.0.
- Fix exe/DhanHQ: was still using the old require "DhanHQ".
- Remove lib/dhanhq/ from the default Zeitwerk autoload path so
  DhanHQ::Analysis::* is no longer loaded on every require 'dhan_hq'.
- Add lib/dhan_hq/analysis.rb (optional require for OptionsBuyingAdvisor
  and MultiTimeframeAnalyzer) and lib/dhan_hq/ta.rb (optional require for
  TA::TechnicalAnalysis and friends).
- Update analysis specs to use require 'dhan_hq/analysis'.
- Expand SimpleCov from models-only to all lib/**/*.rb files.
- Add prominent "not officially affiliated with Dhan" disclaimer to README.
- Update README installation section and badge URL for new gem name.
- Document v2.1.5→v3.0.0 naming history and optional-require pattern.
- Fix gem name references in docs/HOW_TO_USE_DHAN_API_WITH_RUBY.md and
  docs/TECHNICAL_ANALYSIS.md.

https://claude.ai/code/session_01W63HCB1mDJTfmzvmu8HGmR