### PR TITLE
Add agent & MCP support: tool registry, order preview, MCP server, instrument search, docs and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [3.1.0] - 2026-07-02
+
+### Added
+
+- **Agent and MCP support**: Added `DhanHQ::Agent::Policy`, `DhanHQ::Agent::ToolRegistry`, `DhanHQ::Agent::OrderPreview`, and a lightweight stdio MCP server executable, `dhanhq-mcp`, for scoped agent workflows.
+- **Agent-friendly instrument search**: Added `DhanHQ::Models::Instrument.search` and `DhanHQ::Models::SearchResult` for resolving symbols to security IDs from instrument master data.
+- **Ruby agent skill pack**: Added `skills/dhanhq-ruby/SKILL.md` and focused references for safe Ruby SDK usage by coding agents.
+- **AI agent documentation**: Added README guidance and `docs/AI_AGENT_GAP_ANALYSIS.md` covering API/MCP/skills coverage, gaps, and roadmap.
+
+---
+
 ## [3.0.0] - 2026-05-19
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -124,6 +124,36 @@ For the full dependency flow and extension pattern, see [ARCHITECTURE.md](ARCHIT
 
 ---
 
+## AI agents, MCP, and skills
+
+Dhan now documents first-party MCP and Agent Skills surfaces alongside API v2. This gem is still a Ruby SDK first, but its models, resources, contracts, WebSocket clients, live-trading guard, and audit logging make it a strong foundation for Ruby-native agent tooling.
+
+This gem now includes foundational agent support:
+
+- `DhanHQ::Models::Instrument.search` for agent-friendly security resolution
+- `DhanHQ::Agent::OrderPreview` for dry-run order validation and human confirmation summaries
+- `DhanHQ::Agent::Policy` and `DhanHQ::Agent::ToolRegistry` for scoped, machine-readable tools
+- `dhanhq-mcp`, a lightweight stdio MCP server exposing read-only tools by default and write tools only behind `DHANHQ_MCP_ENABLE_WRITES=true` plus `LIVE_TRADING=true`
+- `skills/dhanhq-ruby/SKILL.md`, a Ruby-specific agent skill with safety rules and examples
+
+```ruby
+require "dhan_hq"
+require "dhan_hq/agent"
+
+DhanHQ.configure_with_env
+results = DhanHQ::Models::Instrument.search("RELIANCE", segments: ["NSE_EQ"], limit: 5)
+preview = DhanHQ::Agent::OrderPreview.new(
+  transaction_type: "BUY", exchange_segment: "NSE_EQ", product_type: "INTRADAY",
+  order_type: "MARKET", validity: "DAY", security_id: results.first.security_id,
+  quantity: 1, correlation_id: "agent-001"
+)
+puts preview.to_h
+```
+
+See [docs/AI_AGENT_GAP_ANALYSIS.md](docs/AI_AGENT_GAP_ANALYSIS.md) for the remaining roadmap, including ScanX/scanner support if Dhan publishes public endpoints.
+
+---
+
 ## Reliability & Safety
 
 - retry-on-401 with token refresh

--- a/docs/AI_AGENT_GAP_ANALYSIS.md
+++ b/docs/AI_AGENT_GAP_ANALYSIS.md
@@ -1,0 +1,185 @@
+# DhanHQ API, MCP, and Agent Skills Gap Analysis
+
+This document compares the current Ruby gem surface with the public DhanHQ documentation pages reviewed on 2026-07-02:
+
+- <https://docs.dhanhq.co/api/v2/>
+- <https://docs.dhanhq.co/mcp/>
+- <https://docs.dhanhq.co/skills>
+- <https://docs.dhanhq.co/docs-export.md/>
+
+## Implemented in this gem
+
+This branch adds the first implementation pass for the gaps called out below:
+
+- `DhanHQ::Models::Instrument.search` and `DhanHQ::Models::SearchResult` for local security resolution from the instrument master.
+- `DhanHQ::Agent::Policy` for read/write scopes and environment-backed write gates.
+- `DhanHQ::Agent::ToolRegistry` with JSON-Schema-like metadata for read-only market/portfolio/order tools, order preview, and write tools.
+- `DhanHQ::Agent::OrderPreview` for dry-run order validation and confirmation summaries.
+- `DhanHQ::MCP::Server` plus `exe/dhanhq-mcp` for stdio MCP tool listing/calls.
+- `skills/dhanhq-ruby/SKILL.md` and focused references for Ruby-specific agent usage.
+
+## Current gem coverage
+
+The gem already covers most of the REST and streaming API surface expected from the Dhan API v2 documentation:
+
+| Area | Current gem surface | Notes |
+| --- | --- | --- |
+| Orders | `DhanHQ::Resources::Orders`, `DhanHQ::Models::Order` | Place, modify, cancel, lookup, slicing, and correlation lookup are present. |
+| Super orders | `DhanHQ::Resources::SuperOrders`, `DhanHQ::Models::SuperOrder` | Entry/target/stop-loss order lifecycle is present. |
+| Forever/GTT orders | `DhanHQ::Resources::ForeverOrders`, `DhanHQ::Models::ForeverOrder` | Create, modify, cancel, list, and lookup are present. |
+| Conditional alerts | `DhanHQ::Resources::AlertOrders`, `DhanHQ::Models::AlertOrder` | Alert order lifecycle is present. |
+| Portfolio | holdings, positions, funds, profile resources/models | Core portfolio read APIs are present. |
+| Statements | `DhanHQ::Resources::Statements`, `DhanHQ::Models::LedgerEntry` | Ledger and historical trade statement access is present. |
+| Market snapshots | `DhanHQ::Resources::MarketFeed`, `DhanHQ::Models::MarketFeed` | LTP, OHLC, and quote snapshots are present. |
+| Historical data | `DhanHQ::Resources::HistoricalData`, `DhanHQ::Models::HistoricalData` | Daily and intraday charts are present. |
+| Option chain | `DhanHQ::Resources::OptionChain`, `DhanHQ::Models::OptionChain` | Option chain and expiry list are present. |
+| Expired options | `DhanHQ::Resources::ExpiredOptionsData`, `DhanHQ::Models::ExpiredOptionsData` | Rolling expired option data is present. |
+| Margin | `DhanHQ::Resources::MarginCalculator`, `DhanHQ::Models::Margin` | Single and multi-scrip margin calculations are present. |
+| EDIS | `DhanHQ::Resources::Edis`, `DhanHQ::Models::Edis` | T-PIN, form, bulk form, and inquiry workflows are present. |
+| Trader control | `DhanHQ::Resources::KillSwitch`, `DhanHQ::Resources::PnlExit` | Kill switch and P&L exit are present. |
+| Static IP setup | `DhanHQ::Resources::IpSetup` | Static IP get/set/modify is present. |
+| WebSockets | `DhanHQ::WS`, market depth, orders stream clients | Live feed, market depth, and order update stream clients are present. |
+| Auth lifecycle | token manager, token generator, token renewal, retry-on-401 | Static and dynamic token workflows are present. |
+
+## Gaps against API v2 docs
+
+### 1. Official search/security-resolution workflow
+
+The MCP documentation exposes a search tool for resolving company names, tickers, or indices to Dhan security IDs. The Ruby gem now exposes `DhanHQ::Models::Instrument.search` and `DhanHQ::Models::SearchResult` as a stable local-search wrapper over the instrument master. A dedicated HTTP `Search` resource can still be added later if Dhan publishes a public REST search endpoint.
+
+Recommended addition:
+
+- Keep the local-search wrapper as the default path, and add `DhanHQ::Resources::Search` only if Dhan exposes an HTTP search endpoint.
+- Provide one canonical call such as `DhanHQ::Models::Instrument.search("RELIANCE")` returning security ID, exchange segment, instrument type, lot size, expiry, strike, and display symbol.
+- Make this the required pre-trade resolution path for MCP and skills tooling.
+
+### 2. ScanX / scanner workflows
+
+The public skills material lists ScanX as one of the skill categories. This gem currently includes technical-analysis helpers and options analysis, but no explicit ScanX/scanner resource, model, CLI, or documentation.
+
+Recommended addition:
+
+- Verify whether ScanX has public API endpoints.
+- If public, add resources/contracts/models for scans and scanner result payloads.
+- If not public, document ScanX as intentionally unsupported and route users toward local `TA` and analysis helpers.
+
+### 3. Agent-native tool metadata
+
+The API docs now position DhanHQ as agent-native with MCP and skills. The gem now publishes machine-readable tool metadata through `DhanHQ::Agent::ToolRegistry`. The next improvement is generating more of this metadata directly from existing dry-validation contracts.
+
+Recommended addition:
+
+- Add generated JSON Schemas for high-value operations: order preview/place/modify/cancel, holdings, positions, funds, LTP, quote, option chain, historical data, margin calculator, alerts, and security search.
+- Derive schemas from existing contracts where possible so the Ruby SDK remains the source of truth.
+- Include risk metadata per tool: read-only, order-write, destructive, requires market hours, requires explicit confirmation, and live-trading gated.
+
+### 4. MCP server packaging
+
+Dhan offers a first-party MCP server, and this Ruby gem now includes a lightweight Ruby-native stdio MCP executable, `dhanhq-mcp`, that wraps the SDK. The initial implementation intentionally keeps the transport small and safety-gated.
+
+Recommended addition:
+
+- Add an optional executable, for example `exe/dhanhq-mcp`, powered by a Ruby MCP server library or a small JSON-RPC stdio adapter.
+- Keep it optional so the core SDK remains lightweight.
+- Start with read-only tools, then add trading tools behind confirmation gates.
+- Support stdio first for Claude Desktop/Cursor/Codex-style clients, then HTTP/SSE if there is clear demand.
+
+### 5. Agent skills bundled with gem
+
+Dhan publishes an external skill pack with 12 categories: orders, portfolio, market data, option chain, instruments, funds, live feed, error codes, common workflows, options analysis, backtesting, and ScanX. This gem now bundles `skills/dhanhq-ruby/SKILL.md` to teach agents the Ruby-specific API surface.
+
+Recommended addition:
+
+- Add `skills/dhanhq-ruby/SKILL.md` focused on this gem's Ruby API, not just the Python examples in Dhan docs.
+- Add lazy-loaded references under `skills/dhanhq-ruby/references/` for orders, market data, WebSockets, options, Rails integration, and troubleshooting.
+- Include runnable Ruby snippets that use `require "dhan_hq"`, `DhanHQ.configure_with_env`, models, resources, and safety flags.
+
+### 6. Pre-trade safety preview
+
+The gem blocks order placement unless `LIVE_TRADING=true` and emits audit logs, which is good for application safety. Agent workflows now have `DhanHQ::Agent::OrderPreview`, a dry-run/preview primitive that can be called before any live write tool.
+
+Recommended addition:
+
+- Add an order preview service that validates contract fields, resolves instrument metadata, validates lot size/tick size where possible, estimates margin, and returns a human-confirmable summary.
+- Require MCP/skills trading tools to call preview before place/modify/cancel.
+- Add an idempotency/correlation ID recommendation for every agent-originated write.
+
+### 7. Permission scopes and consent model
+
+Dhan MCP docs describe per-session permissions and explicit consent. The gem currently has environment-level live trading gating, and now also has `DhanHQ::Agent::Policy` as a reusable scope model for agent tools.
+
+Recommended addition:
+
+- Add a `DhanHQ::Agent::Policy` object with scopes such as `portfolio:read`, `market:read`, `orders:read`, `orders:write`, `orders:cancel`, `alerts:write`, and `risk:write`.
+- Make MCP/skill wrappers require explicit grants and deny dangerous actions by default.
+- Keep the existing `LIVE_TRADING=true` guard as the final runtime backstop.
+
+### 8. Documentation alignment
+
+The README advertises full REST coverage, but it does not mention the newer MCP and Agent Skills surfaces. There is also no roadmap explaining whether the gem will wrap Dhan's first-party MCP server, provide a Ruby-native server, or simply publish skill assets.
+
+Recommended addition:
+
+- Add a README section: "AI agents, MCP, and skills".
+- Link this gap analysis from the README.
+- Document a support matrix: first-party Dhan MCP server, Ruby-native MCP server, bundled Ruby skill pack, and existing SDK APIs.
+
+## Recommended implementation roadmap
+
+### Phase 1: Documentation and safety foundations
+
+1. Add README links to MCP, Agent Skills, and this gap analysis.
+2. Add `skills/dhanhq-ruby/SKILL.md` with safety rules and Ruby snippets.
+3. Add an `Agent::Policy` skeleton and tool metadata registry without exposing a server yet.
+4. Add order preview APIs and specs.
+
+### Phase 2: Read-only MCP server
+
+1. Add optional MCP dependencies or a tiny stdio JSON-RPC adapter.
+2. Implement read-only tools: profile, funds, holdings, positions, orders list, trades list, LTP, quote, OHLC, historical data, option chain, expiry list, margin estimate, and search.
+3. Add contract-driven JSON Schemas.
+4. Add integration tests using stubbed SDK responses; do not call live APIs.
+
+### Phase 3: Write-capable MCP tools
+
+1. Add place/modify/cancel order tools only after preview and explicit confirmation.
+2. Add alert order and kill switch tools with stricter scope requirements.
+3. Add audit metadata for `agent_name`, `client_session_id`, `tool_name`, and confirmation transcript hash.
+4. Add an environment variable such as `DHANHQ_MCP_ENABLE_WRITES=true` in addition to `LIVE_TRADING=true`.
+
+### Phase 4: Skill pack maturity
+
+1. Split skills into lazy references mirroring the public Dhan categories.
+2. Add examples for Codex, Claude Code, Cursor, and VS Code-compatible clients.
+3. Add a compatibility note for Dhan's first-party skill pack versus this gem's Ruby-specific skill pack.
+4. Periodically diff public docs against the gem's resource list.
+
+## Proposed MCP tool matrix
+
+| Tool | SDK backing | Risk | Initial support |
+| --- | --- | --- | --- |
+| `dhan_profile` | `DhanHQ::Models::Profile.current` | Read-only | Phase 2 |
+| `dhan_funds` | `DhanHQ::Models::Funds.current` | Read-only | Phase 2 |
+| `dhan_holdings` | `DhanHQ::Models::Holding.all` | Read-only | Phase 2 |
+| `dhan_positions` | `DhanHQ::Models::Position.all` | Read-only | Phase 2 |
+| `dhan_orders` | `DhanHQ::Models::Order.all` | Read-only | Phase 2 |
+| `dhan_trades` | `DhanHQ::Models::Trade.all` | Read-only | Phase 2 |
+| `dhan_search_instruments` | new search wrapper | Read-only | Phase 2 |
+| `dhan_ltp` | `DhanHQ::Models::MarketFeed.ltp` | Read-only | Phase 2 |
+| `dhan_quote` | `DhanHQ::Models::MarketFeed.quote` | Read-only | Phase 2 |
+| `dhan_option_chain` | `DhanHQ::Models::OptionChain.fetch` | Read-only | Phase 2 |
+| `dhan_margin` | `DhanHQ::Models::Margin.calculate` | Read-only but trade-adjacent | Phase 2 |
+| `dhan_order_preview` | new preview service | Read-only but trade-adjacent | Phase 1 |
+| `dhan_place_order` | `DhanHQ::Models::Order.create` | Live write | Phase 3 |
+| `dhan_modify_order` | `DhanHQ::Models::Order#save` / resource modify | Live write | Phase 3 |
+| `dhan_cancel_order` | `DhanHQ::Models::Order#cancel` | Destructive write | Phase 3 |
+| `dhan_alert_create` | `DhanHQ::Models::AlertOrder.create` | Live write | Phase 3 |
+| `dhan_kill_switch` | `DhanHQ::Models::KillSwitch` | Account-level risk write | Phase 3 |
+
+## Open questions
+
+- Does Dhan expose public REST endpoints for search and ScanX, or are these MCP/skill-only capabilities today?
+- Should this gem embed a Ruby-native MCP server, or only provide schemas/helpers used by an external server?
+- Should trading tools require interactive confirmation from MCP clients, cryptographic confirmation tokens, or both?
+- How should WebSocket subscriptions be represented in MCP, given long-lived streams are less natural for request/response tools?
+- Should skill assets live in this gem, in a companion `dhanhq-ruby-skills` package, or both?

--- a/exe/dhanhq-mcp
+++ b/exe/dhanhq-mcp
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "dhan_hq"
+require "dhan_hq/mcp"
+
+DhanHQ.configure_with_env
+DhanHQ::MCP::Server.new.run

--- a/lib/DhanHQ/agent.rb
+++ b/lib/DhanHQ/agent.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require_relative "agent/policy"
+require_relative "agent/tool_registry"
+require_relative "agent/order_preview"
+
+module DhanHQ
+  module Agent
+  end
+end

--- a/lib/DhanHQ/agent/order_preview.rb
+++ b/lib/DhanHQ/agent/order_preview.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module DhanHQ
+  module Agent
+    # Dry-run order validator and human-readable summary for agent workflows.
+    class OrderPreview
+      attr_reader :params, :errors
+
+      def initialize(params)
+        @params = DhanHQ::Agent::ToolRegistry.symbolize(params)
+        @errors = []
+        validate
+      end
+
+      def valid?
+        errors.empty?
+      end
+
+      def to_h
+        {
+          valid: valid?,
+          errors: errors,
+          action: "place_order",
+          risk: "live_order_requires_confirmation",
+          requires: %w[orders:write DHANHQ_MCP_ENABLE_WRITES LIVE_TRADING],
+          summary: summary,
+          order: params
+        }
+      end
+
+      private
+
+      def validate
+        result = DhanHQ::Contracts::PlaceOrderContract.call(params)
+        @errors << result.errors.to_h if result.failure?
+        @errors << "correlation_id is recommended for agent-originated orders" if params[:correlation_id].to_s.empty?
+      end
+
+      def summary
+        side = params[:transaction_type]
+        qty = params[:quantity]
+        security = params[:security_id]
+        segment = params[:exchange_segment]
+        type = params[:order_type]
+        price = params[:price] ? " @ #{params[:price]}" : ""
+        "#{side} #{qty} of #{segment}:#{security} as #{type}#{price}"
+      end
+    end
+  end
+end

--- a/lib/DhanHQ/agent/order_preview.rb
+++ b/lib/DhanHQ/agent/order_preview.rb
@@ -31,7 +31,7 @@ module DhanHQ
       private
 
       def validate
-        result = DhanHQ::Contracts::PlaceOrderContract.call(params)
+        result = DhanHQ::Contracts::PlaceOrderContract.new.call(params)
         @errors << result.errors.to_h if result.failure?
         @errors << "correlation_id is recommended for agent-originated orders" if params[:correlation_id].to_s.empty?
       end

--- a/lib/DhanHQ/agent/policy.rb
+++ b/lib/DhanHQ/agent/policy.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module DhanHQ
+  module Agent
+    # Permission policy for MCP and agent-skill integrations.
+    class Policy
+      READ_SCOPES = %w[portfolio:read market:read orders:read].freeze
+      WRITE_SCOPES = %w[orders:write orders:cancel alerts:write risk:write].freeze
+      ALL_SCOPES = (READ_SCOPES + WRITE_SCOPES).freeze
+
+      attr_reader :scopes
+
+      def initialize(scopes: [])
+        @scopes = Array(scopes).map(&:to_s).uniq.freeze
+        unknown = @scopes - ALL_SCOPES
+        raise ArgumentError, "Unknown agent scopes: #{unknown.join(', ')}" if unknown.any?
+      end
+
+      def self.read_only
+        new(scopes: READ_SCOPES)
+      end
+
+      def self.from_env
+        raw = ENV.fetch("DHANHQ_AGENT_SCOPES", READ_SCOPES.join(","))
+        new(scopes: raw.split(/[\s,]+/).reject(&:empty?))
+      end
+
+      def allow?(scope)
+        @scopes.include?(scope.to_s)
+      end
+
+      def require!(scope)
+        return true if allow?(scope)
+
+        raise DhanHQ::Error, "Agent scope required: #{scope}"
+      end
+
+      def writes_enabled?
+        ENV["DHANHQ_MCP_ENABLE_WRITES"] == "true" && ENV["LIVE_TRADING"] == "true"
+      end
+
+      def require_write!(scope)
+        require!(scope)
+        return true if writes_enabled?
+
+        raise DhanHQ::LiveTradingDisabledError,
+              "Agent write tools require DHANHQ_MCP_ENABLE_WRITES=true and LIVE_TRADING=true"
+      end
+    end
+  end
+end

--- a/lib/DhanHQ/agent/tool_registry.rb
+++ b/lib/DhanHQ/agent/tool_registry.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+module DhanHQ
+  module Agent
+    # Machine-readable tool metadata shared by MCP and agent skills.
+    module ToolRegistry
+      Tool = Struct.new(:name, :description, :scope, :risk, :schema, :handler, keyword_init: true) do
+        def to_h
+          { name: name, description: description, scope: scope, risk: risk, input_schema: schema }
+        end
+      end
+
+      module_function
+
+      def tools
+        @tools ||= build_tools.freeze
+      end
+
+      def find(name)
+        tools.fetch(name.to_s) { raise ArgumentError, "Unknown DhanHQ agent tool: #{name}" }
+      end
+
+      def list
+        tools.values.map(&:to_h)
+      end
+
+      def execute(name, arguments = {}, policy: Policy.from_env)
+        tool = find(name)
+        if tool.risk.to_s.end_with?("write") || tool.risk == "destructive_write"
+          policy.require_write!(tool.scope)
+        else
+          policy.require!(tool.scope)
+        end
+        tool.handler.call(symbolize(arguments))
+      end
+
+      def build_tools
+        [
+          tool("dhan_profile", "Fetch Dhan profile", "portfolio:read", "read_only", object_schema, profile_handler),
+          tool("dhan_funds", "Fetch fund limits", "portfolio:read", "read_only", object_schema, funds_handler),
+          tool("dhan_holdings", "List holdings", "portfolio:read", "read_only", object_schema, holdings_handler),
+          tool("dhan_positions", "List positions", "portfolio:read", "read_only", object_schema, positions_handler),
+          tool("dhan_orders", "List orders", "orders:read", "read_only", object_schema, orders_handler),
+          tool("dhan_trades", "List trades", "orders:read", "read_only", object_schema, trades_handler),
+          tool("dhan_search_instruments", "Resolve symbols to security IDs", "market:read", "read_only", search_schema,
+               search_handler),
+          tool("dhan_ltp", "Fetch last traded prices", "market:read", "read_only", feed_schema, ltp_handler),
+          tool("dhan_quote", "Fetch market quotes", "market:read", "read_only", feed_schema, quote_handler),
+          tool("dhan_order_preview", "Validate and summarize an order without placing it", "orders:read",
+               "trade_adjacent_read", order_schema, preview_handler),
+          tool("dhan_place_order", "Place an order after external confirmation", "orders:write", "live_write",
+               order_schema, place_order_handler),
+          tool("dhan_cancel_order", "Cancel an order", "orders:cancel", "destructive_write", cancel_schema,
+               cancel_order_handler)
+        ].to_h { |tool_item| [tool_item.name, tool_item] }
+      end
+
+      def tool(name, description, scope, risk, schema, handler)
+        Tool.new(name: name, description: description, scope: scope, risk: risk, schema: schema, handler: handler)
+      end
+
+      def object_schema
+        { type: "object", properties: {}, additionalProperties: false }
+      end
+
+      def search_schema
+        {
+          type: "object",
+          required: ["query"],
+          properties: {
+            query: { type: "string" },
+            segments: { type: "array", items: { type: "string" } },
+            limit: { type: "integer", minimum: 1, maximum: 100 },
+            exact_match: { type: "boolean" }
+          },
+          additionalProperties: false
+        }
+      end
+
+      def feed_schema
+        {
+          type: "object",
+          required: ["instruments"],
+          properties: {
+            instruments: {
+              type: "object",
+              additionalProperties: { type: "array", items: { type: %w[integer string] } }
+            }
+          },
+          additionalProperties: false
+        }
+      end
+
+      def order_schema
+        {
+          type: "object",
+          required: %w[transaction_type exchange_segment product_type order_type validity security_id quantity],
+          properties: {
+            transaction_type: enum(%w[BUY SELL]),
+            exchange_segment: { type: "string" },
+            product_type: { type: "string" },
+            order_type: { type: "string" },
+            validity: { type: "string" },
+            security_id: { type: "string" },
+            quantity: { type: "integer", minimum: 1 },
+            price: { type: "number" },
+            trigger_price: { type: "number" },
+            correlation_id: { type: "string" }
+          },
+          additionalProperties: true
+        }
+      end
+
+      def cancel_schema
+        {
+          type: "object",
+          required: ["order_id"],
+          properties: { order_id: { type: "string" } },
+          additionalProperties: false
+        }
+      end
+
+      def enum(values)
+        { type: "string", enum: values }
+      end
+
+      def profile_handler = ->(_) { DhanHQ::Models::Profile.fetch }
+
+      def funds_handler = ->(_) { DhanHQ::Models::Funds.fetch }
+
+      def holdings_handler = ->(_) { DhanHQ::Models::Holding.all }
+
+      def positions_handler = ->(_) { DhanHQ::Models::Position.all }
+
+      def orders_handler = ->(_) { DhanHQ::Models::Order.all }
+
+      def trades_handler = ->(_) { DhanHQ::Models::Trade.today }
+
+      def search_handler
+        lambda do |arguments|
+          query = arguments.fetch(:query)
+          options = arguments.reject { |key, _| key == :query }
+          DhanHQ::Models::Instrument.search(query, **options)
+        end
+      end
+
+      def ltp_handler = ->(arguments) { DhanHQ::Models::MarketFeed.ltp(arguments[:instruments]) }
+
+      def quote_handler = ->(arguments) { DhanHQ::Models::MarketFeed.quote(arguments[:instruments]) }
+
+      def preview_handler = ->(arguments) { OrderPreview.new(arguments).to_h }
+
+      def place_order_handler = ->(arguments) { DhanHQ::Models::Order.place(arguments) }
+
+      def cancel_order_handler
+        lambda do |arguments|
+          order = DhanHQ::Models::Order.find(arguments[:order_id])
+          order&.cancel || false
+        end
+      end
+
+      def symbolize(value)
+        case value
+        when Hash then value.each_with_object({}) { |(key, val), hash| hash[key.to_sym] = symbolize(val) }
+        when Array then value.map { |val| symbolize(val) }
+        else value
+        end
+      end
+    end
+  end
+end

--- a/lib/DhanHQ/mcp.rb
+++ b/lib/DhanHQ/mcp.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require_relative "mcp/server"
+
+module DhanHQ
+  module MCP
+  end
+end

--- a/lib/DhanHQ/mcp/server.rb
+++ b/lib/DhanHQ/mcp/server.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "json"
+require_relative "../agent"
+
+module DhanHQ
+  module MCP
+    # Minimal MCP-compatible stdio JSON-RPC server for DhanHQ agent tools.
+    class Server
+      def initialize(input: $stdin, output: $stdout, policy: DhanHQ::Agent::Policy.from_env)
+        @input = input
+        @output = output
+        @policy = policy
+      end
+
+      def run
+        @input.each_line { |line| handle_line(line) }
+      end
+
+      def handle_line(line)
+        request = JSON.parse(line)
+        respond(request["id"], dispatch(request["method"], request["params"] || {}))
+      rescue StandardError => e
+        respond(nil, nil, code: -32_000, message: e.message)
+      end
+
+      private
+
+      def dispatch(method, params)
+        case method
+        when "initialize"
+          {
+            protocolVersion: "2024-11-05",
+            serverInfo: { name: "dhanhq-ruby", version: DhanHQ::VERSION },
+            capabilities: { tools: {} }
+          }
+        when "tools/list"
+          { tools: DhanHQ::Agent::ToolRegistry.list.map { |t| mcp_tool(t) } }
+        when "tools/call"
+          result = DhanHQ::Agent::ToolRegistry.execute(
+            params.fetch("name"),
+            params.fetch("arguments", {}),
+            policy: @policy
+          )
+          { content: [{ type: "text", text: JSON.pretty_generate(serialize(result)) }] }
+        else
+          raise ArgumentError, "Unsupported MCP method: #{method}"
+        end
+      end
+
+      def mcp_tool(tool)
+        { name: tool[:name], description: "[#{tool[:risk]}] #{tool[:description]}", inputSchema: tool[:input_schema] }
+      end
+
+      def serialize(value)
+        case value
+        when Array then value.map { |v| serialize(v) }
+        when Hash then value.transform_values { |v| serialize(v) }
+        else
+          value.respond_to?(:attributes) ? value.attributes : value
+        end
+      end
+
+      def respond(id, result, code: nil, message: nil)
+        payload = { jsonrpc: "2.0", id: id }
+        code ? payload[:error] = { code: code, message: message } : payload[:result] = result
+        @output.puts(JSON.generate(payload))
+        @output.flush
+      end
+    end
+  end
+end

--- a/lib/DhanHQ/models/instrument.rb
+++ b/lib/DhanHQ/models/instrument.rb
@@ -2,6 +2,7 @@
 
 require_relative "../contracts/instrument_list_contract"
 require_relative "instrument_helpers"
+require_relative "search_result"
 
 module DhanHQ
   module Models
@@ -112,6 +113,42 @@ module DhanHQ
           end
 
           nil
+        end
+
+
+        # Search instruments across segments and return agent-friendly search results.
+        # @param query [String] symbol/company/index text
+        # @param options [Hash] :segments, :limit, :exact_match, :case_sensitive
+        # @return [Array<DhanHQ::Models::SearchResult>]
+        def search(query, options = {})
+          raise ArgumentError, "query is required" if query.to_s.strip.empty?
+
+          limit = Integer(options.fetch(:limit, 20))
+          segments = options[:segments] || %w[NSE_EQ BSE_EQ IDX_I NSE_FNO BSE_FNO NSE_CURRENCY BSE_CURRENCY MCX_COMM]
+          exact_match = options.fetch(:exact_match, false)
+          case_sensitive = options.fetch(:case_sensitive, false)
+          needle = case_sensitive ? query.to_s : query.to_s.upcase
+
+          results = []
+          segments.each do |segment|
+            by_segment(segment).each do |instrument|
+              haystacks = [
+                instrument.symbol_name,
+                instrument.display_name,
+                instrument.underlying_symbol,
+                instrument.isin
+              ].compact
+              matched = haystacks.any? do |value|
+                comparable = case_sensitive ? value.to_s : value.to_s.upcase
+                exact_match ? comparable == needle : comparable.include?(needle)
+              end
+              next unless matched
+
+              results << DhanHQ::Models::SearchResult.new(instrument.attributes, skip_validation: true)
+              return results if results.length >= limit
+            end
+          end
+          results
         end
 
         def normalize_csv_row(row)

--- a/lib/DhanHQ/models/search_result.rb
+++ b/lib/DhanHQ/models/search_result.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module DhanHQ
+  module Models
+    # Lightweight result returned by Instrument.search for agent-friendly security resolution.
+    class SearchResult < BaseModel
+      attributes :security_id, :symbol_name, :display_name, :exchange_segment, :instrument,
+                 :instrument_type, :lot_size, :tick_size, :expiry_date, :strike_price,
+                 :option_type, :underlying_symbol, :isin
+    end
+  end
+end

--- a/lib/DhanHQ/version.rb
+++ b/lib/DhanHQ/version.rb
@@ -2,5 +2,5 @@
 
 module DhanHQ
   # Semantic version of the DhanHQ client gem.
-  VERSION = "3.0.0"
+  VERSION = "3.1.0"
 end

--- a/lib/dhan_hq.rb
+++ b/lib/dhan_hq.rb
@@ -31,6 +31,7 @@ module DhanHQ
     "base_api" => "BaseAPI",
     "ip_setup" => "IPSetup",
     "json_loader" => "JSONLoader",
+    "mcp" => "MCP",
     "ws" => "WS"
   )
   LOADER.push_dir(File.join(__dir__, "DhanHQ"), namespace: self)

--- a/lib/dhan_hq/agent.rb
+++ b/lib/dhan_hq/agent.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative "../DhanHQ/agent"

--- a/lib/dhan_hq/mcp.rb
+++ b/lib/dhan_hq/mcp.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative "../DhanHQ/mcp"

--- a/skills/dhanhq-ruby/SKILL.md
+++ b/skills/dhanhq-ruby/SKILL.md
@@ -1,0 +1,74 @@
+# DhanHQ Ruby SDK Skill
+
+Use this skill when an agent needs to write, review, or operate Ruby code using the `DhanHQ` gem.
+
+## Safety rules
+
+- Prefer read-only tools and SDK calls unless the user explicitly asks to trade.
+- Resolve instruments before trading with `DhanHQ::Models::Instrument.search` and use the returned `security_id` plus `exchange_segment`.
+- Preview every order with `DhanHQ::Agent::OrderPreview` before any live order placement.
+- Never place, modify, or cancel orders unless both `DHANHQ_MCP_ENABLE_WRITES=true` and `LIVE_TRADING=true` are set and the user has clearly confirmed the action.
+- Include a `correlation_id` for every agent-originated order.
+- Do not ask for or print access tokens.
+
+## Setup
+
+```ruby
+require "dhan_hq"
+require "dhan_hq/agent"
+
+DhanHQ.configure_with_env
+```
+
+Required environment variables:
+
+- `DHAN_CLIENT_ID`
+- `DHAN_ACCESS_TOKEN`
+
+Optional agent variables:
+
+- `DHANHQ_AGENT_SCOPES`, comma-separated scopes such as `portfolio:read,market:read,orders:read`
+- `DHANHQ_MCP_ENABLE_WRITES=true` for agent write tools
+- `LIVE_TRADING=true` for any live trading write
+
+## Common calls
+
+```ruby
+DhanHQ::Models::Profile.fetch
+DhanHQ::Models::Funds.fetch
+DhanHQ::Models::Holding.all
+DhanHQ::Models::Position.all
+DhanHQ::Models::Order.all
+DhanHQ::Models::Trade.today
+DhanHQ::Models::Instrument.search("RELIANCE", segments: ["NSE_EQ"], limit: 5)
+DhanHQ::Models::MarketFeed.ltp("NSE_EQ" => ["2885"])
+```
+
+## Order preview
+
+```ruby
+preview = DhanHQ::Agent::OrderPreview.new(
+  transaction_type: "BUY",
+  exchange_segment: "NSE_EQ",
+  product_type: "INTRADAY",
+  order_type: "MARKET",
+  validity: "DAY",
+  security_id: "2885",
+  quantity: 1,
+  correlation_id: "agent-20260702-001"
+)
+
+preview.to_h
+```
+
+## MCP server
+
+The gem includes a stdio MCP executable:
+
+```bash
+dhanhq-mcp
+```
+
+Start with read-only scopes. Add write scopes only for explicitly confirmed trading sessions.
+
+See the references directory for focused workflows.

--- a/skills/dhanhq-ruby/references/market_data.md
+++ b/skills/dhanhq-ruby/references/market_data.md
@@ -1,0 +1,3 @@
+# Market data with agents
+
+Use `DhanHQ::Models::Instrument.search` to resolve a query to Dhan security IDs, then call `DhanHQ::Models::MarketFeed.ltp`, `.ohlc`, or `.quote` with an exchange-segment keyed payload.

--- a/skills/dhanhq-ruby/references/orders.md
+++ b/skills/dhanhq-ruby/references/orders.md
@@ -1,0 +1,7 @@
+# Orders with agents
+
+1. Search or otherwise verify the instrument.
+2. Build order params using Dhan constants and API docs.
+3. Run `DhanHQ::Agent::OrderPreview.new(params).to_h`.
+4. Ask the user to confirm the preview.
+5. Place only if `DHANHQ_MCP_ENABLE_WRITES=true`, `LIVE_TRADING=true`, and `orders:write` scope are present.

--- a/spec/dhan_hq/agent/order_preview_spec.rb
+++ b/spec/dhan_hq/agent/order_preview_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe DhanHQ::Agent::OrderPreview do
+  let(:params) do
+    {
+      transaction_type: "BUY",
+      exchange_segment: "NSE_EQ",
+      product_type: "INTRADAY",
+      order_type: "MARKET",
+      validity: "DAY",
+      security_id: "2885",
+      quantity: 1,
+      correlation_id: "agent-test-1"
+    }
+  end
+
+  it "returns a valid dry-run summary without placing an order" do
+    preview = described_class.new(params).to_h
+
+    expect(preview[:valid]).to be(true)
+    expect(preview[:summary]).to include("BUY 1 of NSE_EQ:2885")
+    expect(preview[:requires]).to include("LIVE_TRADING")
+  end
+end

--- a/spec/dhan_hq/agent/policy_spec.rb
+++ b/spec/dhan_hq/agent/policy_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe DhanHQ::Agent::Policy do
+  it "defaults to read-only scopes from env helper" do
+    ENV.delete("DHANHQ_AGENT_SCOPES")
+
+    policy = described_class.from_env
+
+    expect(policy).to be_allow("portfolio:read")
+    expect(policy).not_to be_allow("orders:write")
+  end
+
+  it "blocks write scopes unless both write env flags are enabled" do
+    policy = described_class.new(scopes: ["orders:write"])
+    ENV.delete("DHANHQ_MCP_ENABLE_WRITES")
+    ENV.delete("LIVE_TRADING")
+
+    expect { policy.require_write!("orders:write") }.to raise_error(DhanHQ::LiveTradingDisabledError)
+  end
+end

--- a/spec/dhan_hq/agent/tool_registry_spec.rb
+++ b/spec/dhan_hq/agent/tool_registry_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+RSpec.describe DhanHQ::Agent::ToolRegistry do
+  it "lists MCP-ready tool metadata" do
+    names = described_class.list.map { |tool| tool[:name] }
+
+    expect(names).to include("dhan_search_instruments", "dhan_order_preview", "dhan_place_order")
+  end
+
+  it "executes order preview with read-only order scope" do
+    policy = DhanHQ::Agent::Policy.new(scopes: ["orders:read"])
+
+    result = described_class.execute(
+      "dhan_order_preview",
+      {
+        "transaction_type" => "BUY",
+        "exchange_segment" => "NSE_EQ",
+        "product_type" => "INTRADAY",
+        "order_type" => "MARKET",
+        "validity" => "DAY",
+        "security_id" => "2885",
+        "quantity" => 1,
+        "correlation_id" => "agent-test-2"
+      },
+      policy: policy
+    )
+
+    expect(result[:valid]).to be(true)
+  end
+end

--- a/spec/dhan_hq/mcp/server_spec.rb
+++ b/spec/dhan_hq/mcp/server_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "stringio"
+require "DhanHQ/mcp"
+
+RSpec.describe DhanHQ::MCP::Server do
+  it "responds to tools/list" do
+    output = StringIO.new
+    server = described_class.new(input: StringIO.new, output: output, policy: DhanHQ::Agent::Policy.read_only)
+
+    server.handle_line({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }.to_json)
+
+    response = JSON.parse(output.string)
+    expect(response.dig("result", "tools").map { |tool| tool["name"] }).to include("dhan_order_preview")
+  end
+end

--- a/spec/dhan_hq/models/instrument_search_spec.rb
+++ b/spec/dhan_hq/models/instrument_search_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.describe DhanHQ::Models::Instrument do
+  it "searches instruments and returns SearchResult models" do
+    allow(described_class).to receive(:by_segment).with("NSE_EQ").and_return([
+      described_class.new(
+        {
+          security_id: "2885",
+          symbol_name: "RELIANCE",
+          display_name: "Reliance Industries",
+          exchange_segment: "NSE_EQ"
+        },
+        skip_validation: true
+      )
+    ])
+
+    results = described_class.search("reliance", segments: ["NSE_EQ"])
+
+    expect(results.first).to be_a(DhanHQ::Models::SearchResult)
+    expect(results.first.security_id).to eq("2885")
+  end
+end


### PR DESCRIPTION
### Motivation

- Expose a machine-friendly surface for AI agents and Dhan MCP clients so agents can safely resolve instruments, preview orders, and call SDK-backed tools. 
- Provide safety and scope controls so write operations remain gated behind explicit environment flags and permission scopes. 
- Offer a minimal stdio MCP server and a packaged `dhanhq-mcp` executable to enable quick integration with MCP-compatible clients. 
- Document gaps and examples for agent workflows and ship a Ruby-specific skill pack to guide safe agent usage. 

### Description

- Add an `Agent` subsystem with `DhanHQ::Agent::Policy`, `DhanHQ::Agent::ToolRegistry`, and `DhanHQ::Agent::OrderPreview` to model scopes, tools, and dry-run order summaries. 
- Implement a minimal stdio JSON-RPC MCP server at `DhanHQ::MCP::Server` and an executable `exe/dhanhq-mcp` that runs it, plus lightweight MCP wiring in `lib/dhan_hq/mcp.rb` and autoloader changes. 
- Add instrument search and a lightweight `SearchResult` model via `DhanHQ::Models::Instrument.search` and `lib/DhanHQ/models/search_result.rb` for agent-friendly security resolution. 
- Ship documentation and skill assets: `docs/AI_AGENT_GAP_ANALYSIS.md`, `skills/dhanhq-ruby/SKILL.md`, and focused references under `skills/dhanhq-ruby/references/`. 
- Update top-level loader to include `MCP`, and add multiple specs under `spec/dhan_hq/agent/*`, `spec/dhan_hq/mcp/*`, and `spec/dhan_hq/models/*` to cover the new surfaces. 

### Testing

- Ran the new RSpec suite via `bundle exec rspec` covering `Agent::OrderPreview`, `Agent::Policy`, `Agent::ToolRegistry`, `MCP::Server`, and `Models::Instrument` search behavior. 
- The added specs `spec/dhan_hq/agent/order_preview_spec.rb`, `spec/dhan_hq/agent/policy_spec.rb`, `spec/dhan_hq/agent/tool_registry_spec.rb`, `spec/dhan_hq/mcp/server_spec.rb`, and `spec/dhan_hq/models/instrument_search_spec.rb` executed successfully. 
- No automated test failures were observed for the modified and newly added tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45e1270b1c83318573f8cbdb2be7d0)