### PR TITLE
Correct rate limits to match published DhanHQ API documentation

### DIFF
--- a/docs/CONSTANTS_REFERENCE.md
+++ b/docs/CONSTANTS_REFERENCE.md
@@ -457,10 +457,11 @@ DhanHQ::Constants.all_for(:OrderType) # => ["LIMIT", "MARKET", ...]
 
 | API Type | Per Second | Per Minute | Per Hour | Per Day |
 |----------|------------|------------|----------|---------|
-| Order APIs | 10 | 250 | 1,000 | 7,000 |
-| Data APIs | 5 | - | - | 100,000 |
+| Order APIs | 10 | Unlimited | Unlimited | 100,000 |
+| Data APIs | 5 | - | - | 7,000 |
 | Quote APIs | 1 | Unlimited | Unlimited | Unlimited |
 | Non Trading APIs | 20 | Unlimited | Unlimited | Unlimited |
+| Option Chain | 1 per 3 sec | - | - | - |
 
 **Note:** Order modifications are capped at 25 modifications per order.
 

--- a/lib/DhanHQ/constants.rb
+++ b/lib/DhanHQ/constants.rb
@@ -381,9 +381,10 @@ module DhanHQ
 
     # Public rate limits published in DhanHQ API documentation.
     module RateLimit
-      ORDER_API = { per_second: 10, per_minute: 250, per_hour: 1000, per_day: 7000 }.freeze
-      DATA_API = { per_second: 5, per_day: 100_000 }.freeze
+      ORDER_API = { per_second: 10, per_day: 100_000 }.freeze
+      DATA_API = { per_second: 5, per_day: 7_000 }.freeze
       QUOTE_API = { per_second: 1 }.freeze
+      OPTION_CHAIN = { per_second: 1.0 / 3 }.freeze
       NON_TRADING_API = { per_second: 20 }.freeze
       ORDER_MODIFICATIONS_PER_ORDER = 25
     end

--- a/lib/DhanHQ/rate_limiter.rb
+++ b/lib/DhanHQ/rate_limiter.rb
@@ -5,10 +5,12 @@ require "concurrent"
 module DhanHQ
   # Coarse-grained in-memory throttler matching the platform rate limits.
   class RateLimiter
-    # Per-interval thresholds keyed by API type.
+    # Per-interval thresholds keyed by API type, matching the published
+    # DhanHQ rate-limit table (Order APIs: 10/sec, 100,000/day;
+    # Data APIs: 5/sec, 7,000/day; Market Quote: 1/sec; Option Chain: 1 per 3 sec).
     RATE_LIMITS = {
-      order_api: { per_second: 25, per_minute: 250, per_hour: 1000, per_day: 7000 },
-      data_api: { per_second: 5, per_minute: Float::INFINITY, per_hour: Float::INFINITY, per_day: 100_000 },
+      order_api: { per_second: 10, per_minute: Float::INFINITY, per_hour: Float::INFINITY, per_day: 100_000 },
+      data_api: { per_second: 5, per_minute: Float::INFINITY, per_hour: Float::INFINITY, per_day: 7_000 },
       quote_api: { per_second: 1, per_minute: Float::INFINITY, per_hour: Float::INFINITY, per_day: Float::INFINITY },
       option_chain: { per_second: 1.0 / 3, per_minute: 20, per_hour: 600, per_day: 4800 },
       non_trading_api: { per_second: 20, per_minute: Float::INFINITY, per_hour: Float::INFINITY,

--- a/spec/dhan_hq/rate_limiter_spec.rb
+++ b/spec/dhan_hq/rate_limiter_spec.rb
@@ -67,8 +67,9 @@ RSpec.describe DhanHQ::RateLimiter do
       expect(rate_limiter.instance_variable_get(:@request_times).size).to eq(limit)
     end
 
-    it "returns false when exceeding the per_minute limit" do
-      rate_limiter.instance_variable_get(:@buckets)[:per_minute].value = 250
+    it "returns false when exceeding the per_day limit" do
+      limit = DhanHQ::RateLimiter::RATE_LIMITS[:order_api][:per_day]
+      rate_limiter.instance_variable_get(:@buckets)[:per_day].value = limit
       expect(rate_limiter.send(:allow_request?)).to be false
     end
   end
@@ -108,28 +109,9 @@ RSpec.describe DhanHQ::RateLimiter do
       expect(request_times.size).to eq(0)
     end
 
-    it "resets per_minute limit after 60 seconds" do
-      rate_limiter.instance_variable_get(:@buckets)[:per_minute].value = 250
-      expect(rate_limiter.send(:allow_request?)).to be false
-
-      Timecop.travel(60) # Simulate 60 seconds passing
-      rate_limiter.instance_variable_get(:@buckets)[:per_minute].value = 0
-
-      expect(rate_limiter.send(:allow_request?)).to be true
-    end
-
-    it "resets per_hour limit after 3600 seconds" do
-      rate_limiter.instance_variable_get(:@buckets)[:per_hour].value = 1000
-      expect(rate_limiter.send(:allow_request?)).to be false
-
-      Timecop.travel(3600) # Simulate 1 hour passing
-      rate_limiter.instance_variable_get(:@buckets)[:per_hour].value = 0
-
-      expect(rate_limiter.send(:allow_request?)).to be true
-    end
-
     it "resets per_day limit after 86,400 seconds (1 day)" do
-      rate_limiter.instance_variable_get(:@buckets)[:per_day].value = 7000
+      limit = DhanHQ::RateLimiter::RATE_LIMITS[:order_api][:per_day]
+      rate_limiter.instance_variable_get(:@buckets)[:per_day].value = limit
       expect(rate_limiter.send(:allow_request?)).to be false
 
       Timecop.travel(86_400) # Simulate 1 day passing
@@ -141,25 +123,31 @@ RSpec.describe DhanHQ::RateLimiter do
 
   describe "configured limits" do
     context "when api type is order_api" do
-      it "enforces documented thresholds" do
+      it "caps at 10 per second and 100,000 per day per the published limits" do
+        expect(DhanHQ::RateLimiter::RATE_LIMITS[:order_api][:per_second]).to eq(10)
+        expect(DhanHQ::RateLimiter::RATE_LIMITS[:order_api][:per_day]).to eq(100_000)
+      end
+
+      it "allows unlimited minute/hour traffic but blocks at the daily cap" do
         buckets = rate_limiter.instance_variable_get(:@buckets)
 
         # per_second is handled via timestamps in throttle!, not in allow_request?
-        buckets[:per_minute].value = 250
-        expect(rate_limiter.send(:allow_request?)).to be false
+        buckets[:per_minute].value = 10_000
+        buckets[:per_hour].value = 50_000
+        expect(rate_limiter.send(:allow_request?)).to be true
 
-        buckets[:per_minute].value = 0
-        buckets[:per_hour].value = 1000
-        expect(rate_limiter.send(:allow_request?)).to be false
-
-        buckets[:per_hour].value = 0
-        buckets[:per_day].value = 7000
+        buckets[:per_day].value = 100_000
         expect(rate_limiter.send(:allow_request?)).to be false
       end
     end
 
     context "when api type is data_api" do
       let(:api_type) { :data_api }
+
+      it "caps at 5 per second and 7,000 per day per the published limits" do
+        expect(DhanHQ::RateLimiter::RATE_LIMITS[:data_api][:per_second]).to eq(5)
+        expect(DhanHQ::RateLimiter::RATE_LIMITS[:data_api][:per_day]).to eq(7_000)
+      end
 
       it "allows unlimited minute/hour traffic but caps per_second (via timestamps) and per_day" do
         buckets = rate_limiter.instance_variable_get(:@buckets)
@@ -171,7 +159,7 @@ RSpec.describe DhanHQ::RateLimiter do
 
         buckets[:per_minute].value = 0
         buckets[:per_hour].value = 0
-        buckets[:per_day].value = 100_000
+        buckets[:per_day].value = 7_000
         expect(rate_limiter.send(:allow_request?)).to be false
       end
     end


### PR DESCRIPTION
## Summary
Aligns the `RateLimiter` configuration and published constants with the actual DhanHQ API rate-limit table. The previous implementation had incorrect thresholds for Order APIs and Data APIs, and enforced per-minute/per-hour limits that don't exist in the published documentation.

## Key Changes

- **Order APIs**: Corrected from 25/sec, 250/min, 1,000/hr, 7,000/day → **10/sec, unlimited/min, unlimited/hr, 100,000/day**
- **Data APIs**: Corrected from 5/sec, unlimited/min, unlimited/hr, 100,000/day → **5/sec, unlimited/min, unlimited/hr, 7,000/day**
- Removed per-minute and per-hour bucket enforcement for Order and Data APIs (set to `Float::INFINITY`)
- Updated `DhanHQ::Constants::RateLimit` to reflect published limits (removed per-minute/per-hour where not applicable)
- Added `OPTION_CHAIN` constant (1 request per 3 seconds)
- Updated documentation table in `CONSTANTS_REFERENCE.md` to clarify unlimited minute/hour traffic and per-day caps
- Refactored rate-limiter tests to validate the corrected limits and remove obsolete per-minute/per-hour reset tests

## Implementation Details

The rate limiter now correctly:
- Enforces per-second limits via timestamp tracking in `throttle!`
- Enforces per-day limits via token bucket in `allow_request?`
- Treats per-minute and per-hour as unlimited (no enforcement) for Order and Data APIs
- Maintains backward compatibility for APIs with actual minute/hour limits (Option Chain, Non-Trading)

All test assertions updated to reflect the published rate-limit table.

https://claude.ai/code/session_014qPRfo8VpvyqudPA2oa4AV