### PR TITLE
Restore the Claude Agent Skill pack to the published gem

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -158,6 +158,11 @@ RSpec/RepeatedExample:
   Exclude:
     - 'spec/dhan_hq/contracts/expired_options_data_contract_spec.rb'
 
+# Packaging is not a class, so there is nothing for `describe` to name.
+RSpec/DescribeClass:
+  Exclude:
+    - 'spec/dhan_hq/gem_packaging_spec.rb'
+
 # Offense count: 1
 # Configuration parameters: CustomTransform, IgnoreMethods, IgnoreMetadata, InflectorPath, EnforcedInflector.
 # SupportedInflectors: default, active_support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [Unreleased]
+
+### Fixed
+
+- **Restored the Claude Agent Skill pack to the published gem.** Switching `spec.files` from a reject-list to an allowlist in 3.2.0 stripped 51 MB of junk (a 36 MB core dump and a 17 MB `diagram.html`), but it also dropped `skills/dhanhq-ruby/` — 28 files, 164 KB: `SKILL.md` and its trigger frontmatter, 12 reference guides, 11 examples and 4 helper scripts. That pack is product content, added deliberately in #41. No Ruby code loads it at runtime, so nothing broke and no spec noticed; users installing 3.2.0 simply stopped receiving it. `CODE_OF_CONDUCT.md` and `AGENTS.md` are restored alongside it.
+
+  Unaffected and still shipped throughout: the MCP server (`lib/DhanHQ/mcp/`, `exe/dhanhq-mcp`), the agent tool layer (all 32 tools), the Ruby skills classes (`lib/DhanHQ/skills/`, 11 builtin skills), the risk pipeline and the WebSocket subsystem.
+
+  Gem size: 3.1.0 was 5.9 MB, 3.2.0 was 292 KB, and this is 324 KB. The 20× reduction is real and almost entirely the core dump; the skill pack was collateral.
+
+### Added
+
+- **`spec/dhan_hq/gem_packaging_spec.rb`** — pins both ends of what ships, since packaging has now failed in both directions. Asserts the entry point, both executables, RBS signatures, Rails initializer, MCP server, agent tool layer, Ruby skills and the Claude Skill pack are all present; asserts the known junk, any crash dump, the spec suite and development config are all absent; and caps the uncompressed payload at 3 MB so a stray binary fails loudly rather than silently adding megabytes to a release.
+
 ## [3.2.0] - 2026-07-25
 
 ### Added

--- a/DhanHQ.gemspec
+++ b/DhanHQ.gemspec
@@ -30,8 +30,11 @@ Gem::Specification.new do |spec|
   # 17 MB diagram.html — 51 MB of a 52 MB gem — went out in releases. An allowlist
   # cannot leak an unanticipated artifact: a new file is only published if a maintainer
   # adds its directory here.
-  shipped_directories = %w[lib exe sig config docs].freeze
-  shipped_root_files = %w[README.md CHANGELOG.md ARCHITECTURE.md GUIDE.md LICENSE.txt].freeze
+  # `skills/` is the Claude Agent Skill pack (SKILL.md, references, examples,
+  # helper scripts) that ships with the gem as product content, not build output.
+  shipped_directories = %w[lib exe sig config docs skills].freeze
+  shipped_root_files = %w[README.md CHANGELOG.md ARCHITECTURE.md GUIDE.md LICENSE.txt
+                          CODE_OF_CONDUCT.md AGENTS.md].freeze
   # Draft PR write-ups live under docs/ but are not user documentation.
   excluded_patterns = [%r{\Adocs/PR_}].freeze
 

--- a/spec/dhan_hq/gem_packaging_spec.rb
+++ b/spec/dhan_hq/gem_packaging_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+# Guards what the published gem contains.
+#
+# Two failures have already happened here, in opposite directions:
+#
+# 1. A reject-list `spec.files` shipped a 36 MB core dump and a 17 MB diagram.html,
+#    making the released gem 5.9 MB of which 5.6 MB was junk.
+# 2. Replacing it with an allowlist built from "what does the Ruby runtime need"
+#    silently dropped `skills/`, the Claude Agent Skill pack — product content that no
+#    Ruby code loads, so no other spec noticed.
+#
+# These examples pin both ends: the product content that must ship, and the artifacts
+# that must not.
+RSpec.describe "gem packaging" do
+  subject(:gemspec) { Gem::Specification.load(File.expand_path("../../DhanHQ.gemspec", __dir__)) }
+
+  let(:files) { gemspec.files }
+
+  describe "library and executables" do
+    it "ships the entry point and both executables" do
+      expect(files).to include("lib/dhan_hq.rb", "exe/dhanhq-mcp", "exe/DhanHQ")
+      expect(gemspec.executables).to contain_exactly("DhanHQ", "dhanhq-mcp")
+    end
+
+    it "ships the RBS signatures and the Rails initializer" do
+      expect(files).to include("sig/DhanHQ.rbs", "config/initializers/order_update_hub.rb")
+    end
+  end
+
+  describe "AI-facing surfaces" do
+    it "ships the MCP server" do
+      expect(files).to include("lib/DhanHQ/mcp.rb", "lib/DhanHQ/mcp/server.rb")
+    end
+
+    it "ships the agent tool layer" do
+      expect(files).to include(
+        "lib/DhanHQ/agent/tool_registry.rb",
+        "lib/DhanHQ/agent/tool_catalogue.rb",
+        "lib/DhanHQ/agent/tool_schemas.rb",
+        "lib/DhanHQ/agent/tool_handlers.rb"
+      )
+    end
+
+    it "ships the Ruby skills classes" do
+      expect(files).to include("lib/DhanHQ/skills/registry.rb", "lib/DhanHQ/skills/builtin/iron_condor.rb")
+    end
+
+    # The pack is consumed by Claude as an Agent Skill, not by this gem's runtime, so
+    # nothing else in the suite would notice its absence.
+    it "ships the Claude Agent Skill pack" do
+      expect(files).to include("skills/dhanhq-ruby/SKILL.md")
+      expect(files.grep(%r{\Askills/dhanhq-ruby/references/})).not_to be_empty
+      expect(files.grep(%r{\Askills/dhanhq-ruby/examples/})).not_to be_empty
+      expect(files.grep(%r{\Askills/dhanhq-ruby/scripts/})).not_to be_empty
+    end
+  end
+
+  describe "excluded artifacts" do
+    it "ships none of the files that bloated 3.1.0" do
+      expect(files).not_to include("core", "diagram.html", "TAGS", "watchlist.csv")
+    end
+
+    it "ships no crash dump under any name" do
+      expect(files.grep(/\Acore(\.|\z)|\.core\z/)).to be_empty
+    end
+
+    it "ships no test suite or fixtures" do
+      expect(files.grep(%r{\Aspec/})).to be_empty
+    end
+
+    it "ships no development-only configuration" do
+      expect(files).not_to include("Rakefile", ".rspec", ".rubocop.yml", ".rubocop_todo.yml", "Gemfile")
+    end
+
+    it "ships no draft PR write-ups from docs/" do
+      expect(files.grep(%r{\Adocs/PR_})).to be_empty
+    end
+  end
+
+  describe "payload size" do
+    # A ceiling, not a target. The payload is ~1.2 MB of source and documentation; this
+    # fails loudly if a large binary is ever tracked into a shipped directory again.
+    let(:max_payload_bytes) { 3 * 1024 * 1024 }
+
+    it "stays well under the size a stray binary would push it past" do
+      total = files.sum { |path| File.exist?(path) ? File.size(path) : 0 }
+
+      expect(total).to be < max_payload_bytes
+    end
+
+    it "references only files that exist" do
+      expect(files.reject { |path| File.exist?(path) }).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes a regression I introduced in #46. The allowlist that stripped 51 MB of junk from the gem also dropped `skills/dhanhq-ruby/` — product content, not build output.

## What happened

#46 switched `spec.files` from a reject-list to an allowlist, because the reject-list was shipping a 36 MB core dump (`core`, from an unrelated `light-locker` process) and a 17 MB `diagram.html` — 51 MB of a 52 MB gem.

The allowlist was built from *"what does the Ruby runtime need"*. That question has the wrong scope, and it silently excluded 28 files, 164 KB:

```
skills/dhanhq-ruby/SKILL.md              ← trigger frontmatter
skills/dhanhq-ruby/references/  (12)     ← orders, option-chain, portfolio, error-codes, …
skills/dhanhq-ruby/examples/    (11)     ← place_equity_order.rb, iron_condor.rb, …
skills/dhanhq-ruby/scripts/     (4)      ← dhan_helpers.rb, validate_order.rb, …
```

That's the Claude Agent Skill pack added in #41. No Ruby code loads it at runtime, so nothing broke and the full suite stayed green — it just stopped reaching anyone installing the gem. My verification in #46 ("all 217 `lib/` files and both executables intact") was true but was the wrong thing to check.

## Not affected

Confirmed present throughout, by inspecting the built gem's manifest:

| | Files |
|---|---|
| MCP server — `lib/DhanHQ/mcp/`, `exe/dhanhq-mcp` | 2 + 1 |
| Agent tool layer — all 32 tools | 9 |
| Ruby skills classes — 11 builtin skills | 15 |
| Risk pipeline / WebSocket subsystem | 12 / 28 |

## Gem size

| | Size | Files |
|---|---|---|
| 3.1.0 | 5.9 MB | 269 |
| 3.2.0 (current `main`) | 292 KB | 259 |
| this PR | 324 KB | 291 |

The 20× reduction is real and almost entirely the core dump, which compresses to ~5.6 MB of the old 5.9 MB. The skill pack was 164 KB of collateral. File count exceeds 3.1.0's because 3.2.0 added 30 files.

## Still excluded, deliberately

`core`, `diagram.html`, `TAGS`, `watchlist.csv` (junk), and `Rakefile`, `.rspec`, `.rubocop.yml`, `.rubocop_todo.yml` (development config, inert in an installed gem).

## Guard against recurrence

Packaging has now failed in **both** directions — shipping 51 MB of junk, then dropping 164 KB of product content. `spec/dhan_hq/gem_packaging_spec.rb` pins both ends:

- asserts the entry point, both executables, RBS signatures, Rails initializer, MCP server, agent tool layer, Ruby skills and the Claude Skill pack all ship
- asserts the known junk, any crash dump under any name, the spec suite and dev config all do not
- caps the uncompressed payload at 3 MB, so a stray binary fails loudly rather than quietly adding megabytes to a release

Verified by building the gem at `8106c44` (pre-3.2.0) and at this commit and diffing the manifests: the only remaining removals are the four junk files and the four dev config files.

## Tests

1,065 examples, 0 failures; RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRpDEPqunpn9PxYGmNVjk3

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRpDEPqunpn9PxYGmNVjk3)_