### PR TITLE
Add rails generate dhanhq:install generator

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,11 @@ AllCops:
   NewCops: enable
   Exclude:
     - "skills/**/*"
+    # Generator template output -- mirrors the target Rails app's conventions
+    # (and the already-verified docs/RAILS_INTEGRATION.md patterns), not this
+    # gem's own style, and references Rails/Sidekiq/ActionCable constants that
+    # don't exist in this gem's own context.
+    - "lib/generators/**/templates/**/*"
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,10 @@ gem "simplecov", "~> 0.22", require: false, groups: %i[development test]
 
 group :test do
   gem "timecop"
+  # Provides Rails::Generators::Base, needed to load and test the
+  # `dhanhq:install` generator under lib/generators/. This gem stays
+  # Rails-free at runtime -- railties is dev/test-only.
+  gem "railties"
 end
 
 # Optional tools for local technical analysis experiments (not part of the gem)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,23 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (8.1.2)
+    actionpack (8.1.3.1)
+      actionview (= 8.1.3.1)
+      activesupport (= 8.1.3.1)
+      nokogiri (>= 1.8.5)
+      rack (>= 2.2.4)
+      rack-session (>= 1.0.1)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+      useragent (~> 0.16)
+    actionview (8.1.3.1)
+      activesupport (= 8.1.3.1)
+      builder (~> 3.1)
+      erubi (~> 1.11)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    activesupport (8.1.3.1)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
@@ -40,6 +56,7 @@ GEM
     base64 (0.3.0)
     bigdecimal (4.0.1)
     bindata (2.5.1)
+    builder (3.3.0)
     childprocess (5.1.0)
       logger (~> 1.5)
     coercible (1.0.0)
@@ -49,6 +66,7 @@ GEM
     crack (1.0.1)
       bigdecimal
       rexml
+    crass (1.0.7)
     csv (3.3.5)
     date (3.5.1)
     debug (1.11.1)
@@ -137,6 +155,9 @@ GEM
       logger (~> 1.6)
     lint_roller (1.1.0)
     logger (1.7.0)
+    loofah (2.25.2)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
     mcp (0.8.0)
       json-schema (>= 4.1)
     minitest (6.0.2)
@@ -144,6 +165,8 @@ GEM
       prism (~> 1.5)
     net-http (0.9.1)
       uri (>= 0.11.1)
+    nokogiri (1.19.4-x86_64-linux-gnu)
+      racc (~> 1.4)
     ostruct (0.6.3)
     parallel (1.27.0)
     parser (3.3.10.2)
@@ -160,6 +183,29 @@ GEM
     public_suffix (7.0.5)
     racc (1.8.1)
     rack (2.2.22)
+    rack-session (1.0.2)
+      rack (< 3)
+    rack-test (2.2.0)
+      rack (>= 1.3)
+    rackup (1.0.1)
+      rack (< 3)
+      webrick
+    rails-dom-testing (2.3.0)
+      activesupport (>= 5.0.0)
+      minitest
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
+      nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    railties (8.1.3.1)
+      actionpack (= 8.1.3.1)
+      activesupport (= 8.1.3.1)
+      irb (~> 1.13)
+      rackup (>= 1.0.0)
+      rake (>= 12.2)
+      thor (~> 1.0, >= 1.2.2)
+      tsort (>= 0.2)
+      zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.3.1)
     rdoc (7.2.0)
@@ -243,6 +289,7 @@ GEM
     simplecov_json_formatter (0.1.4)
     stringio (3.2.0)
     technical-analysis (0.2.4)
+    thor (1.5.0)
     thread_safe (0.3.6)
     timecop (0.9.10)
     tsort (0.2.0)
@@ -253,6 +300,7 @@ GEM
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
     uri (1.1.1)
+    useragent (0.16.11)
     vcr (6.4.0)
     virtus (2.0.0)
       axiom-types (~> 0.1)
@@ -271,7 +319,6 @@ GEM
     zeitwerk (2.7.5)
 
 PLATFORMS
-  ruby
   x86_64-linux
 
 DEPENDENCIES
@@ -279,6 +326,7 @@ DEPENDENCIES
   debug
   dotenv
   rack (~> 2.0)
+  railties
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop (~> 1.21)
@@ -297,18 +345,22 @@ DEPENDENCIES
 
 CHECKSUMS
   DhanHQ (3.3.0)
-  activesupport (8.1.2) sha256=88842578ccd0d40f658289b0e8c842acfe9af751afee2e0744a7873f50b6fdae
+  actionpack (8.1.3.1) sha256=974cb7154548e81f470b1b0f247b99cb38e87825899dca58610596e2817723d0
+  actionview (8.1.3.1) sha256=2da68b8414c47b43bfbed1ce69c5afe1c04f78c267aacb5660a4cab5ca12cfb6
+  activesupport (8.1.3.1) sha256=85458765f25ea48b9019c46b6bb3fa5683197bf4280d9f06710a6e8d7a831376
   addressable (2.8.9) sha256=cc154fcbe689711808a43601dee7b980238ce54368d23e127421753e46895485
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   axiom-types (0.1.1) sha256=c1ff113f3de516fa195b2db7e0a9a95fd1b08475a502ff660d04507a09980383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
   bindata (2.5.1) sha256=53186a1ec2da943d4cb413583d680644eb810aacbf8902497aac8f191fad9e58
+  builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   childprocess (5.1.0) sha256=9a8d484be2fd4096a0e90a0cd3e449a05bc3aa33f8ac9e4d6dcef6ac1455b6ec
   coercible (1.0.0) sha256=5081ad24352cc8435ce5472bc2faa30260c7ea7f2102cc6a9f167c4d9bffaadc
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
+  crass (1.0.7) sha256=94868719948664c89ddcaf0a37c65048413dfcb1c869470a5f7a7ceb5390b295
   csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
@@ -344,9 +396,11 @@ CHECKSUMS
   launchy (3.1.1) sha256=72b847b5cc961589dde2c395af0108c86ff0119f42d4648d25b5440ebb10059e
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  loofah (2.25.2) sha256=2007f746959ac65552456e04b433e83deb22759ab38c838b4445c70e43425918
   mcp (0.8.0) sha256=ae8bd146bb8e168852866fd26f805f52744f6326afb3211e073f78a95e0c34fb
   minitest (6.0.2) sha256=db6e57956f6ecc6134683b4c87467d6dd792323c7f0eea7b93f66bd284adbc3d
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
+  nokogiri (1.19.4-x86_64-linux-gnu) sha256=379fae440b28915e3f19d752ce2dcf8465ed2b2fbefd2a7ca0dd497bc981a06a
   ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912
   parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
   parser (3.3.10.2) sha256=6f60c84aa4bdcedb6d1a2434b738fe8a8136807b6adc8f7f53b97da9bc4e9357
@@ -358,6 +412,12 @@ CHECKSUMS
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (2.2.22) sha256=c5cf0b7f872559966d974abe3101a57d51caf12504ee76290b98720004f64542
+  rack-session (1.0.2) sha256=a02115e5420b4de036839b9811e3f7967d73446a554b42aa45106af335851d76
+  rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
+  rackup (1.0.1) sha256=ba86604a28989fe1043bff20d819b360944ca08156406812dca6742b24b3c249
+  rails-dom-testing (2.3.0) sha256=8acc7953a7b911ca44588bf08737bc16719f431a1cc3091a292bca7317925c1d
+  rails-html-sanitizer (1.7.1) sha256=e797a7c9b01e567307e317c576b49ab4168017e63eea4dba9ce3cb587e2f22c2
+  railties (8.1.3.1) sha256=2388a232579a00cefea4487de66c8553c3408c1300abdc6cf1799d86ffb04487
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.3.1) sha256=8c9e89d09f66a26a01264e7e3480ec0607f0c497a861ef16063604b1b08eb19c
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
@@ -387,6 +447,7 @@ CHECKSUMS
   simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   technical-analysis (0.2.4) sha256=ef4c9041e86c488cf93f20e3cd8eab34dd57a3e44ee8dbcc8bc7f9c0de9e73d0
+  thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
   thread_safe (0.3.6) sha256=9ed7072821b51c57e8d6b7011a8e282e25aeea3a4065eab326e43f66f063b05a
   timecop (0.9.10) sha256=12ba45ce57cdcf6b1043cb6cdffa6381fd89ce10d369c28a7f6f04dc1b0cd8eb
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
@@ -395,6 +456,7 @@ CHECKSUMS
   unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
+  useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
   vcr (6.4.0) sha256=077ac92cc16efc5904eb90492a18153b5e6ca5398046d8a249a7c96a9ea24ae6
   virtus (2.0.0) sha256=8841dae4eb7fcc097320ba5ea516bf1839e5d056c61ee27138aa4bddd6e3d1c2
   webmock (3.26.1) sha256=4f696fb57c90a827c20aadb2d4f9058bbff10f7f043bd0d4c3f58791143b1cd7

--- a/README.md
+++ b/README.md
@@ -721,7 +721,11 @@ sleep   # keep the script alive
 
 ## Rails Integration
 
-Need initializers, service objects, ActionCable wiring, and background workers? See the [Rails Integration Guide](docs/RAILS_INTEGRATION.md).
+```bash
+rails generate dhanhq:install
+```
+
+Scaffolds `config/initializers/dhanhq.rb`, an order-placing service object, a Sidekiq market-feed worker, and an ActionCable channel in one command. For the full picture — service objects, ActionCable wiring, background workers, dynamic token providers — see the [Rails Integration Guide](docs/RAILS_INTEGRATION.md).
 
 ---
 

--- a/docs/RAILS_INTEGRATION.md
+++ b/docs/RAILS_INTEGRATION.md
@@ -21,6 +21,11 @@ bundle install
 If you package the gem privately you can also point to a released version from
 RubyGems.
 
+**Fast path:** `rails generate dhanhq:install` scaffolds the initializer below plus
+a sample order service, a Sidekiq market-feed worker, and an ActionCable channel
+in one command. The rest of this guide covers what it generates and the options
+beyond it (dynamic tokens, order-update streaming, scheduled jobs).
+
 ## 2. Configure credentials & initializer
 
 Store the Dhan client id and access token using Rails credentials or ENV

--- a/lib/generators/dhanhq/install/install_generator.rb
+++ b/lib/generators/dhanhq/install/install_generator.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails/generators"
+
+module Dhanhq
+  # Scaffolds a DhanHQ initializer, a sample order-placing service object, and
+  # a Sidekiq worker + ActionCable channel for streaming market data.
+  #
+  #   rails generate dhanhq:install
+  #
+  class InstallGenerator < Rails::Generators::Base
+    source_root File.expand_path("templates", __dir__)
+
+    def create_initializer
+      template "initializer.rb", "config/initializers/dhanhq.rb"
+    end
+
+    def create_order_service
+      template "place_order_service.rb", "app/services/dhan/orders/place_order.rb"
+    end
+
+    def create_market_feed_worker
+      template "market_feed_worker.rb", "app/workers/dhan_market_feed_worker.rb"
+    end
+
+    def create_market_feed_channel
+      template "market_feed_channel.rb", "app/channels/dhan_market_feed_channel.rb"
+    end
+
+    def show_post_install_message
+      say ""
+      say "DhanHQ installed! Next steps:", :green
+      say "  1. Add your credentials:"
+      say "       rails credentials:edit"
+      say "       dhanhq:"
+      say "         client_id: \"your_client_id\""
+      say "         access_token: \"your_access_token\""
+      say "  2. Set LIVE_TRADING=true before placing real orders (see docs/CONFIGURATION.md)"
+      say "  3. Start the market feed: DhanMarketFeedWorker.perform_async"
+      say ""
+      say "Full reference: https://github.com/shubhamtaywade82/dhanhq-client/blob/main/docs/RAILS_INTEGRATION.md"
+      say ""
+    end
+  end
+end

--- a/lib/generators/dhanhq/install/templates/initializer.rb
+++ b/lib/generators/dhanhq/install/templates/initializer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "dhan_hq"
+
+if (creds = Rails.application.credentials.dig(:dhanhq))
+  ENV["DHAN_CLIENT_ID"]    ||= creds[:client_id]
+  ENV["DHAN_ACCESS_TOKEN"] ||= creds[:access_token]
+end
+
+DhanHQ.configure_with_env
+
+log_level = (ENV["DHAN_LOG_LEVEL"] || "INFO").upcase
+DhanHQ.logger.level = Logger.const_get(log_level)
+
+# Full optional configuration (base_url, ws_order_url, partner auth, timeouts,
+# DHAN_WS_DEBUG, ...) is documented in:
+#   https://github.com/shubhamtaywade82/dhanhq-client/blob/main/docs/CONFIGURATION.md
+#   https://github.com/shubhamtaywade82/dhanhq-client/blob/main/docs/RAILS_INTEGRATION.md

--- a/lib/generators/dhanhq/install/templates/market_feed_channel.rb
+++ b/lib/generators/dhanhq/install/templates/market_feed_channel.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class DhanMarketFeedChannel < ApplicationCable::Channel
+  def subscribed
+    stream_from "dhan_market_feed"
+  end
+end

--- a/lib/generators/dhanhq/install/templates/market_feed_worker.rb
+++ b/lib/generators/dhanhq/install/templates/market_feed_worker.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Keeps a DhanHQ market feed connection open and broadcasts ticks over
+# ActionCable. Start it with DhanMarketFeedWorker.perform_async -- the job
+# blocks for the life of the connection rather than completing immediately,
+# so Sidekiq's dashboard reflects whether the feed is actually running.
+#
+# retry: false because there is nothing to retry: the underlying
+# DhanHQ::WS::Client already reconnects and re-subscribes on its own.
+class DhanMarketFeedWorker
+  include Sidekiq::Worker
+  sidekiq_options retry: false
+
+  def perform(mode = "quote")
+    client = DhanHQ::WS.connect(mode: mode.to_sym) do |tick|
+      ActionCable.server.broadcast("dhan_market_feed", tick)
+    end
+
+    client.on(:reconnect) { |info| Rails.logger.warn("[DhanMarketFeedWorker] reconnect ##{info[:attempt]}") }
+    client.on(:error) { |message| Rails.logger.error("[DhanMarketFeedWorker] #{message}") }
+
+    loop do
+      sleep 30
+      break unless client.connected?
+    end
+  end
+end

--- a/lib/generators/dhanhq/install/templates/place_order_service.rb
+++ b/lib/generators/dhanhq/install/templates/place_order_service.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Dhan
+  module Orders
+    # Places a Dhan order via the bang variant, so a rejection raises a
+    # specific, catchable error instead of Order.place's ambiguous
+    # nil/false/ErrorObject return.
+    class PlaceOrder
+      def initialize(params)
+        @params = params
+      end
+
+      def call
+        DhanHQ::Models::Order.place!(@params)
+      rescue DhanHQ::OrderError => e
+        Rails.logger.error("Dhan order rejected: #{e.message}")
+        raise
+      rescue DhanHQ::RiskViolation => e
+        Rails.logger.warn("Dhan risk check blocked the order: #{e.message}")
+        raise
+      end
+    end
+  end
+end

--- a/spec/generators/dhanhq/install_generator_spec.rb
+++ b/spec/generators/dhanhq/install_generator_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+require "fileutils"
+require "stringio"
+require_relative "../../../lib/generators/dhanhq/install/install_generator"
+
+RSpec.describe Dhanhq::InstallGenerator do
+  let(:destination_root) { Dir.mktmpdir("dhanhq_install_generator_spec") }
+
+  after { FileUtils.remove_entry(destination_root) }
+
+  def run_generator
+    original_stdout = $stdout
+    $stdout = StringIO.new
+    described_class.new([], {}, destination_root: destination_root).invoke_all
+    $stdout.string
+  ensure
+    $stdout = original_stdout
+  end
+
+  def generated(path)
+    File.read(File.join(destination_root, path))
+  end
+
+  it "creates the initializer wired to Rails credentials and configure_with_env" do
+    run_generator
+
+    content = generated("config/initializers/dhanhq.rb")
+    expect(content).to include("Rails.application.credentials.dig(:dhanhq)")
+    expect(content).to include("DhanHQ.configure_with_env")
+  end
+
+  it "creates an order-placing service using the bang variant with a specific rescue per error class" do
+    run_generator
+
+    content = generated("app/services/dhan/orders/place_order.rb")
+    expect(content).to include("module Dhan")
+    expect(content).to include("class PlaceOrder")
+    expect(content).to include("DhanHQ::Models::Order.place!(@params)")
+    expect(content).to include("rescue DhanHQ::OrderError")
+    expect(content).to include("rescue DhanHQ::RiskViolation")
+  end
+
+  it "creates a Sidekiq worker that blocks for the life of the connection" do
+    run_generator
+
+    content = generated("app/workers/dhan_market_feed_worker.rb")
+    expect(content).to include("include Sidekiq::Worker")
+    expect(content).to include("DhanHQ::WS.connect(mode: mode.to_sym)")
+    expect(content).to include('ActionCable.server.broadcast("dhan_market_feed", tick)')
+  end
+
+  it "creates an ActionCable channel that streams from the same name the worker broadcasts to" do
+    run_generator
+
+    worker = generated("app/workers/dhan_market_feed_worker.rb")
+    channel = generated("app/channels/dhan_market_feed_channel.rb")
+
+    expect(channel).to include("class DhanMarketFeedChannel < ApplicationCable::Channel")
+    expect(channel).to include('stream_from "dhan_market_feed"')
+    expect(worker).to include('ActionCable.server.broadcast("dhan_market_feed"')
+  end
+
+  it "prints a post-install message pointing at credentials setup and the worker" do
+    output = run_generator
+
+    expect(output).to include("rails credentials:edit")
+    expect(output).to include("DhanMarketFeedWorker.perform_async")
+  end
+
+  it "only references classes and methods that actually exist in this gem" do
+    # Order.place! (bang variants) and DhanHQ::RiskViolation are exactly the kind of
+    # thing that silently drifts from the real API in hand-written docs/templates --
+    # lock them down here instead of trusting the generated source by inspection alone.
+    expect(DhanHQ::Models::Order).to respond_to(:place!)
+    expect(DhanHQ::OrderError.ancestors).to include(DhanHQ::Error)
+    expect(DhanHQ::RiskViolation.ancestors).to include(DhanHQ::Error)
+  end
+end


### PR DESCRIPTION
## Summary

Closes #52. `rails generate dhanhq:install` scaffolds `config/initializers/dhanhq.rb`, an order-placing service object, a Sidekiq market-feed worker, and an ActionCable channel in one command — closing the "Rails devs copy-pasting from docs" gap `QUICKSTART.md` only partially addressed.

Scoped to **Standard** per the agreed design: initializer + service + worker, plus the ActionCable channel the worker's broadcast needs to actually be useful (a worker broadcasting to nowhere isn't a complete feature).

## Every API call in the templates was verified, not copied on faith

- `Order.place!` / `DhanHQ::OrderError` / `DhanHQ::RiskViolation` in the service template are all real, and `RiskViolation` is confirmed to actually propagate from the order-placing path (`Concerns::OrderAudit#run_risk_checks!` runs `Risk::Pipeline.run!` and rescues `DhanHQ::RiskViolation` before an `OrderError` would ever apply) — so the service's two separate `rescue` clauses are both meaningful, not dead code.
- The worker's "block for the life of the connection" idiom (`loop { sleep 30; break unless client.connected? }`) replaces an initial `ws.wait!`-based draft — **`DhanHQ::WS::Client` has no `wait!`/`wait` method at all**. Traced the real pattern from `examples/market_feed_example.rb` instead.
- That check surfaced that `docs/RAILS_INTEGRATION.md`'s **existing** Sidekiq examples call `wait!`, `subscribe(array)`, and `Client.new(kind:)` — none of which exist on the real API either. Filed as #59 rather than folded in here, since it's a pre-existing, unrelated doc bug that doesn't block this generator.

## Dependency note

Loading and testing `Rails::Generators::Base` requires `railties`, which wasn't in this gem's dependency tree at all (this is an intentionally Rails-free gem per `CLAUDE.md`). Added as a **dev/test-only** dependency (`Gemfile`, `:test` group) — no change to the published gem's runtime dependency footprint (`DhanHQ.gemspec`'s `add_dependency` list is untouched). It does pull in `actionpack`/`actionview` transitively, confined to `:test`.

## Docs

- `README.md` — new one-command callout in the Rails Integration section.
- `docs/RAILS_INTEGRATION.md` — "Fast path" pointer at the top of the install section.
- `.rubocop.yml` — excluded `lib/generators/**/templates/**/*`, mirroring the existing `skills/**/*` precedent: template output mirrors the *target Rails app's* conventions (and the already-verified `RAILS_INTEGRATION.md` patterns, e.g. `credentials.dig(:dhanhq)`), not this gem's own style, and references `Rails`/`Sidekiq`/`ActionCable` constants that don't exist in this gem's own context.

## Test plan

- [x] Manual smoke test: instantiated the generator against a scratch tmp dir via `Thor::Group#invoke_all`, confirmed all 4 files generate with correct content and the post-install message renders correctly.
- [x] `bundle exec rspec` — full suite, 1205 examples, 0 failures.
- [x] `bundle exec rubocop` — 391 files, no offenses.
- [x] New generator spec (`spec/generators/dhanhq/install_generator_spec.rb`, 6 examples) verifies each generated file's content, including a dedicated example asserting `Order.place!`, `DhanHQ::OrderError`, and `DhanHQ::RiskViolation` are real and correctly related — so the generated service template can't silently drift from the actual API the way `RAILS_INTEGRATION.md`'s did.


---
_Generated by [Claude Code](https://claude.ai/code/session_0196hH65vbu8xgAWpqUqjaoV)_