### PR TITLE
Fix broken RAILS_INTEGRATION.md examples, add ActiveJob adapter, pin dry-validation

### DIFF
--- a/DhanHQ.gemspec
+++ b/DhanHQ.gemspec
@@ -61,7 +61,14 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bindata"
   spec.add_dependency "concurrent-ruby"
   spec.add_dependency "csv"
-  spec.add_dependency "dry-validation"
+  # Unpinned, a fresh resolve can land on dry-validation 0.4.1 -- a pre-1.0,
+  # pre-Dry::Validation::Contract API generation from ~2016 that every
+  # contract in lib/DhanHQ/contracts/ (which all subclass BaseContract and use
+  # the modern `rule(...)` block DSL) is incompatible with. Confirmed by
+  # forcing a fresh resolve under Ruby 3.1.6: with no floor, bundler picked
+  # 0.4.1 over 1.11.1 to satisfy the wider Ruby constraint, and every contract
+  # spec failed at require-time.
+  spec.add_dependency "dry-validation", "~> 1.11"
   spec.add_dependency "eventmachine"
   spec.add_dependency "faraday", "~> 2.14"
   spec.add_dependency "faye-websocket"

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,10 @@ group :test do
   # `dhanhq:install` generator under lib/generators/. This gem stays
   # Rails-free at runtime -- railties is dev/test-only.
   gem "railties"
+  # Provides ActiveJob::Base, needed to load and test
+  # DhanHQ::Jobs::PlaceOrderJob under lib/DhanHQ/jobs/. Dev/test-only, same
+  # reasoning as railties above.
+  gem "activejob"
 end
 
 # Optional tools for local technical analysis experiments (not part of the gem)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       bindata
       concurrent-ruby
       csv
-      dry-validation
+      dry-validation (~> 1.11)
       eventmachine
       faraday (~> 2.14)
       faye-websocket
@@ -33,6 +33,9 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
+    activejob (8.1.3.1)
+      activesupport (= 8.1.3.1)
+      globalid (>= 0.3.6)
     activesupport (8.1.3.1)
       base64
       bigdecimal
@@ -134,6 +137,8 @@ GEM
       path_expander (~> 2.0)
       prism (~> 1.7)
       sexp_processor (~> 4.8)
+    globalid (1.4.0)
+      activesupport (>= 6.1)
     hashdiff (1.2.1)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
@@ -323,6 +328,7 @@ PLATFORMS
 
 DEPENDENCIES
   DhanHQ!
+  activejob
   debug
   dotenv
   rack (~> 2.0)
@@ -347,6 +353,7 @@ CHECKSUMS
   DhanHQ (3.3.0)
   actionpack (8.1.3.1) sha256=974cb7154548e81f470b1b0f247b99cb38e87825899dca58610596e2817723d0
   actionview (8.1.3.1) sha256=2da68b8414c47b43bfbed1ce69c5afe1c04f78c267aacb5660a4cab5ca12cfb6
+  activejob (8.1.3.1) sha256=1c8dd275df930df40deecffec63d913a550a33fd94bd298f69721dd96939954a
   activesupport (8.1.3.1) sha256=85458765f25ea48b9019c46b6bb3fa5683197bf4280d9f06710a6e8d7a831376
   addressable (2.8.9) sha256=cc154fcbe689711808a43601dee7b980238ce54368d23e127421753e46895485
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
@@ -385,6 +392,7 @@ CHECKSUMS
   faye-websocket (0.12.0) sha256=ad9f7dfcd0306d0a13baeee450729657661129af15bb5f38716c242484ab42e1
   flay (2.14.2) sha256=d153a8928a0b6f74d4aab7a97577b12440d02df928ffbafb6ebe4bb6730a53f8
   flog (4.9.4) sha256=12cc054fab7a2cbd2a906514397c4d7788954d530564782d6f14939dc2dfbcbb
+  globalid (1.4.0) sha256=037f12fbf1d9d7a014d501c2d5c77356fd4ddd96d7a7991d6700bba96706f427
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   ice_nine (0.11.2) sha256=5d506a7d2723d5592dc121b9928e4931742730131f22a1a37649df1c1e2e63db

--- a/docs/RAILS_INTEGRATION.md
+++ b/docs/RAILS_INTEGRATION.md
@@ -178,6 +178,32 @@ The gem exposes models for positions, holdings, trades, funds, option chains,
 historical bars, etc. Instantiate them the same way (`Model.all`, `.find`,
 `.where`, `#save`).
 
+### Placing orders in the background
+
+For order placement from a controller action or another job, `DhanHQ::Jobs::PlaceOrderJob`
+ships with the gem — no service object required:
+
+```ruby
+DhanHQ::Jobs::PlaceOrderJob.perform_later(
+  transaction_type: DhanHQ::Constants::TransactionType::BUY,
+  exchange_segment: DhanHQ::Constants::ExchangeSegment::NSE_EQ,
+  product_type:     DhanHQ::Constants::ProductType::INTRADAY,
+  order_type:       DhanHQ::Constants::OrderType::LIMIT,
+  validity:         DhanHQ::Constants::Validity::DAY,
+  security_id:      "11536",
+  quantity:         5,
+  price:            1500.0
+)
+```
+
+It calls `Order.place!` and uses ActiveJob's `discard_on` for `DhanHQ::OrderError` and
+`DhanHQ::RiskViolation` — a rejection is logged, not silently retried. This matters because
+DhanHQ order writes are **not idempotent**: most queue adapters (Sidekiq chief among them)
+retry unhandled exceptions at the backend level by default, independent of ActiveJob's own
+opt-in `retry_on`, and a timed-out `POST /v2/orders` retry can place a duplicate order. Don't
+add your own `retry_on DhanHQ::OrderError` on top of this job — that would fight the
+`discard_on` and reintroduce the exact risk it exists to prevent.
+
 ## 4. Centralise error handling
 
 Wrap the gem's exceptions in a concern so Rails controllers and jobs return
@@ -214,21 +240,26 @@ ticks through ActionCable, Redis, or a database.
 # app/workers/dhan/market_feed_worker.rb
 class Dhan::MarketFeedWorker
   include Sidekiq::Worker
+  sidekiq_options retry: false # DhanHQ::WS::Client already reconnects and re-subscribes on its own
 
-  def perform(mode = :quote, securities = [])
-    client = DhanHQ::WS::Client.new(mode: mode.to_sym)
-
-    client.on(:open) { Rails.logger.info('Dhan WS connected') }
-    client.on(:close) { Rails.logger.warn('Dhan WS closed; worker will retry') }
-    client.on(:error) { |err| Rails.logger.error("Dhan WS error: #{err}") }
-
-    client.on(:tick) do |tick|
+  def perform(mode = "quote", securities = [])
+    client = DhanHQ::WS.connect(mode: mode.to_sym) do |tick|
       ActionCable.server.broadcast('market_feed', tick)
     end
 
-    client.start
-    client.subscribe(securities) if securities.any?
-    client.wait! # blocks the worker thread while EventMachine runs
+    client.on(:reconnect) { |info| Rails.logger.warn("Dhan WS reconnect ##{info[:attempt]}") }
+    client.on(:error) { |message| Rails.logger.error("Dhan WS error: #{message}") }
+
+    securities.each { |segment, security_id| client.subscribe_one(segment: segment, security_id: security_id) }
+
+    # Client#start already spawned a background thread and returned -- there is
+    # no blocking wait! method. Hold the worker open for the life of the
+    # connection so Sidekiq doesn't consider the job "done" the instant the
+    # feed opens.
+    loop do
+      sleep 30
+      break unless client.connected?
+    end
   end
 end
 ```
@@ -260,21 +291,28 @@ Use the order-update WebSocket endpoint (configure `ws_order_url` and
 # app/workers/dhan/order_updates_worker.rb
 class Dhan::OrderUpdatesWorker
   include Sidekiq::Worker
+  sidekiq_options retry: false
 
   def perform
-    client = DhanHQ::WS::Client.new(kind: :order_updates)
-
-    client.on(:order_update) do |payload|
-      OrderStatusUpdater.call(payload)
+    client = DhanHQ::WS::Orders.connect do |order_update|
+      OrderStatusUpdater.call(order_update)
     end
 
     client.on(:error) { |err| Rails.logger.error("Dhan order WS error: #{err}") }
 
-    client.start
-    client.wait!
+    loop do
+      sleep 30
+      break unless client.connected?
+    end
   end
 end
 ```
+
+`DhanHQ::WS::Orders::Client` also tracks state for you without any extra
+wiring — `client.order_state(order_no)`, `client.orders_by_status(status)`,
+`client.pending_orders`, and friends stay in sync as updates arrive, so
+`OrderStatusUpdater` doesn't need to re-derive status transitions from raw
+payloads.
 
 Inside `OrderStatusUpdater` you can reconcile the payload with your local order
 records, notify users via ActionCable or email, etc.

--- a/lib/DhanHQ/jobs/place_order_job.rb
+++ b/lib/DhanHQ/jobs/place_order_job.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module DhanHQ
+  module Jobs
+    # Places a Dhan order via ActiveJob, without ever letting a queue adapter
+    # (Sidekiq, Resque, ...) retry it.
+    #
+    # DhanHQ order writes are not idempotent -- a timed-out POST /v2/orders may
+    # already have reached the exchange, so retrying it can place a duplicate
+    # order (see the README's "Order Retries and Duplicate Protection"). Most
+    # adapters retry unhandled exceptions at the backend level by default
+    # (Sidekiq's own retry, independent of ActiveJob's opt-in `retry_on`), so
+    # the only adapter-agnostic way to guarantee this write is never silently
+    # retried is to make sure the exception never reaches the adapter at all.
+    # `discard_on` does exactly that: it's handled inside ActiveJob's own
+    # `execute`, so from the adapter's point of view the job completed, not
+    # failed -- there is nothing left for the adapter's own retry logic to
+    # act on.
+    #
+    # @example
+    #   DhanHQ::Jobs::PlaceOrderJob.perform_later(
+    #     transaction_type: DhanHQ::Constants::TransactionType::BUY,
+    #     exchange_segment: DhanHQ::Constants::ExchangeSegment::NSE_EQ,
+    #     product_type:     DhanHQ::Constants::ProductType::INTRADAY,
+    #     order_type:       DhanHQ::Constants::OrderType::LIMIT,
+    #     validity:         DhanHQ::Constants::Validity::DAY,
+    #     security_id:      "11536",
+    #     quantity:         5,
+    #     price:            1500.0
+    #   )
+    class PlaceOrderJob < ActiveJob::Base
+      discard_on DhanHQ::OrderError do |_job, error|
+        DhanHQ.logger&.error("[DhanHQ::Jobs::PlaceOrderJob] order rejected: #{error.message}")
+      end
+
+      discard_on DhanHQ::RiskViolation do |_job, error|
+        DhanHQ.logger&.warn("[DhanHQ::Jobs::PlaceOrderJob] risk check blocked the order: #{error.message}")
+      end
+
+      # @param params [Hash] Same params accepted by DhanHQ::Models::Order.place.
+      # @return [DhanHQ::Models::Order]
+      def perform(params)
+        DhanHQ::Models::Order.place!(params)
+      end
+    end
+  end
+end

--- a/spec/dhan_hq/docs/rails_integration_examples_spec.rb
+++ b/spec/dhan_hq/docs/rails_integration_examples_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Locks down the WebSocket API surface that docs/RAILS_INTEGRATION.md's
+# Sidekiq worker examples (§5, §6) call by name. The previous versions of
+# those examples called client.wait!, client.subscribe(array), and
+# DhanHQ::WS::Client.new(kind: :order_updates) -- none of which exist -- and
+# nothing caught the drift until it was checked by hand while building the
+# dhanhq:install generator. This is that check, kept as a regression guard.
+# rubocop:disable RSpec/DescribeClass -- this spec is a docs regression guard, not a class spec
+RSpec.describe "docs/RAILS_INTEGRATION.md Sidekiq examples" do
+  describe "market feed worker (§5)" do
+    it "DhanHQ::WS.connect exists and returns something with the methods the example calls" do
+      expect(DhanHQ::WS).to respond_to(:connect)
+      expect(DhanHQ::WS::Client.instance_methods).to include(:on, :subscribe_one, :connected?)
+    end
+
+    it "DhanHQ::WS::Client has no blocking wait method -- the example must not call one" do
+      expect(DhanHQ::WS::Client.instance_methods).not_to include(:wait, :wait!)
+    end
+  end
+
+  describe "order updates worker (§6)" do
+    it "DhanHQ::WS::Orders.connect exists and returns something with the methods the example calls" do
+      expect(DhanHQ::WS::Orders).to respond_to(:connect)
+      expect(DhanHQ::WS::Orders::Client.instance_methods).to include(:on, :connected?)
+    end
+
+    it "DhanHQ::WS::Orders::Client has no blocking wait method -- the example must not call one" do
+      expect(DhanHQ::WS::Orders::Client.instance_methods).not_to include(:wait, :wait!)
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/dhan_hq/jobs/place_order_job_spec.rb
+++ b/spec/dhan_hq/jobs/place_order_job_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "active_job"
+
+RSpec.describe DhanHQ::Jobs::PlaceOrderJob do
+  let(:params) do
+    {
+      transaction_type: "BUY", exchange_segment: "NSE_EQ", product_type: "INTRADAY",
+      order_type: "LIMIT", validity: "DAY", security_id: "11536", quantity: 5, price: 1500.0
+    }
+  end
+
+  describe "#perform" do
+    it "places the order via the bang variant" do
+      order = instance_double(DhanHQ::Models::Order)
+      allow(DhanHQ::Models::Order).to receive(:place!).with(params).and_return(order)
+
+      described_class.perform_now(params)
+
+      expect(DhanHQ::Models::Order).to have_received(:place!).with(params)
+    end
+
+    # discard_on is handled inside ActiveJob's own execute, before an exception
+    # would ever reach a queue adapter's (Sidekiq's, chief among them) own
+    # backend-level retry. Proving the exception never escapes perform_now is
+    # exactly what proves no adapter -- whichever one a consuming app uses --
+    # gets a chance to retry this non-idempotent write.
+    it "discards on OrderError rather than letting it raise out of perform_now" do
+      allow(DhanHQ::Models::Order).to receive(:place!).and_raise(DhanHQ::OrderError, "rejected")
+
+      expect { described_class.perform_now(params) }.not_to raise_error
+    end
+
+    it "discards on RiskViolation rather than letting it raise out of perform_now" do
+      allow(DhanHQ::Models::Order).to receive(:place!).and_raise(DhanHQ::RiskViolation, "blocked")
+
+      expect { described_class.perform_now(params) }.not_to raise_error
+    end
+
+    it "logs a rejected order instead of silently swallowing it" do
+      allow(DhanHQ::Models::Order).to receive(:place!).and_raise(DhanHQ::OrderError, "rejected")
+      allow(DhanHQ.logger).to receive(:error)
+
+      described_class.perform_now(params)
+
+      expect(DhanHQ.logger).to have_received(:error).with(/order rejected: rejected/)
+    end
+
+    it "logs a risk-blocked order instead of silently swallowing it" do
+      allow(DhanHQ::Models::Order).to receive(:place!).and_raise(DhanHQ::RiskViolation, "blocked")
+      allow(DhanHQ.logger).to receive(:warn)
+
+      described_class.perform_now(params)
+
+      expect(DhanHQ.logger).to have_received(:warn).with(/risk check blocked the order: blocked/)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Three of the four remaining tracked issues from the assessment thread. #55 (Ruby floor) concludes "keep 3.2" with a code fix that came out of the investigation regardless.

### Closes #59

`docs/RAILS_INTEGRATION.md`'s §5/§6 Sidekiq examples called `client.wait!`, `client.subscribe(array)`, and `DhanHQ::WS::Client.new(kind: :order_updates)` — none of which exist on the real API (found while building the `dhanhq:install` generator in #60). Replaced with the real, working idiom: `DhanHQ::WS.connect`/`DhanHQ::WS::Orders.connect` plus a `connected?`-based liveness loop, since `Client` has no blocking wait method at all. Added `spec/dhan_hq/docs/rails_integration_examples_spec.rb` to lock down the method names these examples call, so this can't silently drift again.

### Closes #53

`DhanHQ::Jobs::PlaceOrderJob` — an ActiveJob wrapper around `Order.place!`. Uses `discard_on` for `DhanHQ::OrderError`/`DhanHQ::RiskViolation` rather than a manual `rescue`: `discard_on` is handled inside ActiveJob's own `execute`, before an exception would ever reach a queue adapter's backend-level retry (Sidekiq retries unhandled exceptions by default, independent of ActiveJob's own opt-in `retry_on`) — the only adapter-agnostic way to guarantee this non-idempotent write is never silently retried, regardless of which backend a consuming app uses.

### #55 — investigated, floor stays at 3.2, but surfaced a real fix

Full findings posted on #55. Short version: this gem's own code needed only two trivial fixes (anonymous `**` forwarding, Ruby 3.2-only), but forcing a fresh dependency resolve under Ruby 3.1.6 revealed `dry-validation` has **no version floor** in the gemspec — bundler picked `0.4.1` (a 2016-era, pre-`Dry::Validation::Contract` API every contract in this gem is incompatible with) to satisfy the wider Ruby constraint. Fixed that regardless of the floor decision:

```ruby
spec.add_dependency "dry-validation", "~> 1.11"
```

With that fixed, the 3.1 resolve still forced `activesupport` down to 7.2.3.2 (AS 8.x itself requires Ruby ≥ 3.2), and AS 7-vs-8 behavioral differences broke `ToolRegistry`, `MCP::Server`, and `Risk::Pipeline` — 63 failures across unrelated areas, not a syntax problem. That's a materially larger compatibility surface than this investigation's scope, so the floor stays at 3.2. No `TargetRubyVersion`/CI-matrix/docs changes needed since nothing changed.

## Test plan

- [x] `bundle exec rspec` — full suite, 1214 examples, 0 failures
- [x] `bundle exec rubocop` — 394 files, no offenses
- [x] New specs: `place_order_job_spec.rb` (5 examples covering the bang-variant call, `discard_on` for both error classes, and that both get logged rather than silently swallowed) and `rails_integration_examples_spec.rb` (asserts the real API surface the corrected doc examples call, and that `Client`/`Orders::Client` have no `wait`/`wait!` method — so a future edit reintroducing that mistake fails CI instead of silently shipping)
- [x] Manually forced a fresh `bundle install` under Ruby 3.1.6 twice (before and after the `dry-validation` pin) to get the actual evidence above, not a guess from grepping syntax


---
_Generated by [Claude Code](https://claude.ai/code/session_0196hH65vbu8xgAWpqUqjaoV)_